### PR TITLE
Preparation for using Extended keys

### DIFF
--- a/src/chaincode.hpp
+++ b/src/chaincode.hpp
@@ -46,9 +46,9 @@ class ChainCode {
     void Serialize(uint8_t *buffer) const;
     std::vector<uint8_t> Serialize() const;
 
- private:
     // Prevent direct construction, use static constructor
     ChainCode() {}
+private:
 
     bn_t chainCode;
 };

--- a/src/extendedprivatekey.hpp
+++ b/src/extendedprivatekey.hpp
@@ -105,13 +105,13 @@ private:
           chainCode(code),
           sk(key) {}
 
-    const uint32_t version;
-    const uint8_t depth;
-    const uint32_t parentFingerprint;
-    const uint32_t childNumber;
+    uint32_t version;
+    uint8_t depth;
+    uint32_t parentFingerprint;
+    uint32_t childNumber;
 
-    const ChainCode chainCode;
-    const PrivateKey sk;
+    ChainCode chainCode;
+    PrivateKey sk;
 };
 } // end namespace bls
 

--- a/src/extendedprivatekey.hpp
+++ b/src/extendedprivatekey.hpp
@@ -84,7 +84,16 @@ class ExtendedPrivateKey {
 
     ~ExtendedPrivateKey();
 
- private:
+    // Blank public constructor
+    ExtendedPrivateKey()
+            : version(0),
+              depth(0),
+              parentFingerprint(0),
+              childNumber(0),
+              chainCode(ChainCode()),
+              sk(PrivateKey()) {}
+
+private:
     // Private constructor, force use of static methods
     explicit ExtendedPrivateKey(const uint32_t v, const uint8_t d,
                                 const uint32_t pfp, const uint32_t cn,

--- a/src/extendedpublickey.hpp
+++ b/src/extendedpublickey.hpp
@@ -96,13 +96,13 @@ private:
           chainCode(code),
           pk(key) {}
 
-    const uint32_t version;
-    const uint8_t depth;
-    const uint32_t parentFingerprint;
-    const uint32_t childNumber;
+    uint32_t version;
+    uint8_t depth;
+    uint32_t parentFingerprint;
+    uint32_t childNumber;
 
-    const ChainCode chainCode;
-    const PublicKey pk;
+    ChainCode chainCode;
+    PublicKey pk;
 };
 } // end namespace bls
 

--- a/src/extendedpublickey.hpp
+++ b/src/extendedpublickey.hpp
@@ -75,7 +75,16 @@ class ExtendedPublicKey {
     void Serialize(uint8_t *buffer) const;
     std::vector<uint8_t> Serialize() const;
 
- private:
+    // Blank public constructor
+    ExtendedPublicKey()
+            : version(0),
+              depth(0),
+              parentFingerprint(0),
+              childNumber(0),
+              chainCode(ChainCode()),
+              pk(PublicKey()) {}
+
+private:
     // private constructor, force use of static methods
     explicit ExtendedPublicKey(const uint32_t v, const uint8_t d,
                                const uint32_t pfp, const uint32_t cn,


### PR DESCRIPTION
Currently in Dash, we use just one BLS key. This is probably fine for everything we've done up until this point, however going into the future, it'll become more important that we are using derived keys. This is for a couple of reasons:

1. It'll allow us to share a dedicated privatekey with Platform and other services that may want to be able to sign messages directly with the operator BLS key. Currently this is not possible because it would compromise ChainLocks and InstantSend security
2. It is generally good cryptographic process to use derived keys where possible. Sometimes attacks exist where an attacker with a large amount of cipertext or ciphertext/plaintext pairs can calculate a privatekey based on the ciphertexts / plaintexts and public key
