### PR TITLE
go-bindings|github: Drop relative paths in LDFLAGS and CXXFLAGS + Adjust include paths

### DIFF
--- a/.github/workflows/bls-signatures.yml
+++ b/.github/workflows/bls-signatures.yml
@@ -17,7 +17,7 @@ jobs:
         mkdir build
         cd build
         cmake ..
-        make
+        sudo make install
     - name: Test src
       run: |
         ./build/src/runtest

--- a/go-bindings/aggregationinfo.cpp
+++ b/go-bindings/aggregationinfo.cpp
@@ -14,7 +14,7 @@
 
 #include "aggregationinfo.h"
 #include <vector>
-#include "bls.hpp"
+#include "chiabls/bls.hpp"
 #include "publickey.h"
 #include "error.h"
 

--- a/go-bindings/aggregationinfo.go
+++ b/go-bindings/aggregationinfo.go
@@ -1,7 +1,7 @@
 package blschia
 
-// #cgo LDFLAGS: -L../build -lchiabls -lstdc++ -lgmp
-// #cgo CXXFLAGS: -std=c++14 -I../src -I../build/contrib/relic/include -I../contrib/relic/include
+// #cgo LDFLAGS: -lchiabls -lstdc++ -lgmp
+// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "blschia.h"

--- a/go-bindings/blschia.cpp
+++ b/go-bindings/blschia.cpp
@@ -14,7 +14,7 @@
 
 #include "blschia.h"
 #include <string>
-#include "bls.hpp"
+#include "chiabls/bls.hpp"
 #include "error.h"
 
 std::string gErrMsg;

--- a/go-bindings/chaincode.cpp
+++ b/go-bindings/chaincode.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bls.hpp"
+#include "chiabls/bls.hpp"
 #include "chaincode.h"
 #include "error.h"
 

--- a/go-bindings/chaincode.go
+++ b/go-bindings/chaincode.go
@@ -1,7 +1,7 @@
 package blschia
 
-// #cgo LDFLAGS: -L../build -lchiabls -lstdc++ -lgmp
-// #cgo CXXFLAGS: -std=c++14 -I../src -I../build/contrib/relic/include -I../contrib/relic/include
+// #cgo LDFLAGS: -lchiabls -lstdc++ -lgmp
+// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "chaincode.h"

--- a/go-bindings/extendedprivatekey.cpp
+++ b/go-bindings/extendedprivatekey.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bls.hpp"
+#include "chiabls/bls.hpp"
 #include "extendedprivatekey.h"
 #include "privatekey.h"
 #include "publickey.h"

--- a/go-bindings/extendedprivatekey.go
+++ b/go-bindings/extendedprivatekey.go
@@ -1,7 +1,7 @@
 package blschia
 
-// #cgo LDFLAGS: -L../build -lchiabls -lstdc++ -lgmp
-// #cgo CXXFLAGS: -std=c++14 -I../src -I../build/contrib/relic/include -I../contrib/relic/include
+// #cgo LDFLAGS: -lchiabls -lstdc++ -lgmp
+// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "extendedprivatekey.h"

--- a/go-bindings/extendedpublickey.cpp
+++ b/go-bindings/extendedpublickey.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bls.hpp"
+#include "chiabls/bls.hpp"
 #include "extendedpublickey.h"
 #include "publickey.h"
 #include "chaincode.h"

--- a/go-bindings/extendedpublickey.go
+++ b/go-bindings/extendedpublickey.go
@@ -1,7 +1,7 @@
 package blschia
 
-// #cgo LDFLAGS: -L../build -lchiabls -lstdc++ -lgmp
-// #cgo CXXFLAGS: -std=c++14 -I../src -I../build/contrib/relic/include -I../contrib/relic/include
+// #cgo LDFLAGS: -lchiabls -lstdc++ -lgmp
+// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "blschia.h"

--- a/go-bindings/privatekey.cpp
+++ b/go-bindings/privatekey.cpp
@@ -14,7 +14,7 @@
 
 #include "privatekey.h"
 #include <vector>
-#include "bls.hpp"
+#include "chiabls/bls.hpp"
 #include "blschia.h"
 #include "error.h"
 

--- a/go-bindings/privatekey.go
+++ b/go-bindings/privatekey.go
@@ -1,7 +1,7 @@
 package blschia
 
-// #cgo LDFLAGS: -L../build -lchiabls -lstdc++ -lgmp
-// #cgo CXXFLAGS: -std=c++14 -I../src -I../build/contrib/relic/include -I../contrib/relic/include
+// #cgo LDFLAGS: -lchiabls -lstdc++ -lgmp
+// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "privatekey.h"

--- a/go-bindings/publickey.cpp
+++ b/go-bindings/publickey.cpp
@@ -15,7 +15,7 @@
 #include "publickey.h"
 #include <vector>
 #include <cstring>
-#include "bls.hpp"
+#include "chiabls/bls.hpp"
 #include "error.h"
 
 void* CPublicKeySerialize(CPublicKey inPtr) {

--- a/go-bindings/publickey.go
+++ b/go-bindings/publickey.go
@@ -1,7 +1,7 @@
 package blschia
 
-// #cgo LDFLAGS: -L../build -lchiabls -lstdc++ -lgmp
-// #cgo CXXFLAGS: -std=c++14 -I../src -I../build/contrib/relic/include -I../contrib/relic/include
+// #cgo LDFLAGS: -lchiabls -lstdc++ -lgmp
+// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "publickey.h"

--- a/go-bindings/signature.cpp
+++ b/go-bindings/signature.cpp
@@ -14,7 +14,7 @@
 
 #include "signature.h"
 #include <vector>
-#include "bls.hpp"
+#include "chiabls/bls.hpp"
 #include "error.h"
 
 void* CInsecureSignatureSerialize(CInsecureSignature inPtr) {

--- a/go-bindings/signature.go
+++ b/go-bindings/signature.go
@@ -1,7 +1,7 @@
 package blschia
 
-// #cgo LDFLAGS: -L../build -lchiabls -lstdc++ -lgmp
-// #cgo CXXFLAGS: -std=c++14 -I../src -I../build/contrib/relic/include -I../contrib/relic/include
+// #cgo LDFLAGS: -lchiabls -lstdc++ -lgmp
+// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "signature.h"


### PR DESCRIPTION
They are not required if the BLS library is installed but instead they just lead to unexpected behaviour in some cases where the bindings are used out of the repo's folder structure or if the library in there hasn't been compiled (which IMO shouldn't be an precondition to only use the bindings?).