### PR TITLE
src|python: Add legacy and threshold support

### DIFF
--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -418,7 +418,7 @@ PYBIND11_MODULE(blspy, m)
                 return G2Element::FromBytes(Bytes(data_ptr, G2Element::SIZE));
             })
         .def("generator", &G2Element::Generator)
-        .def("from_message", py::overload_cast<const std::vector<uint8_t>&, const uint8_t*, int>(&G2Element::FromMessage))
+        .def("from_message", py::overload_cast<const std::vector<uint8_t>&, const uint8_t*, int, bool>(&G2Element::FromMessage))
         .def("negate", &G2Element::Negate)
         .def(
             "__deepcopy__",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(blstmp ${HEADERS}
   ${CMAKE_CURRENT_SOURCE_DIR}/privatekey.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/bls.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/elements.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/legacy.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/schemes.cpp
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(blstmp ${HEADERS}
   ${CMAKE_CURRENT_SOURCE_DIR}/elements.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/legacy.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/schemes.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/threshold.cpp
 )
 
 set(OPREFIX object_)

--- a/src/bls.hpp
+++ b/src/bls.hpp
@@ -21,6 +21,7 @@
 #include "elements.hpp"
 #include "hkdf.hpp"
 #include "hdkeys.hpp"
+#include "threshold.hpp"
 
 namespace bls {
 

--- a/src/elements.hpp
+++ b/src/elements.hpp
@@ -39,8 +39,8 @@ public:
         g1_set_infty(p);
     }
 
-    static G1Element FromBytes(const Bytes& bytes);
-    static G1Element FromByteVector(const std::vector<uint8_t> &bytevec);
+    static G1Element FromBytes(const Bytes& bytes, bool fLegacy = false);
+    static G1Element FromByteVector(const std::vector<uint8_t> &bytevec, bool fLegacy = false);
     static G1Element FromNative(const g1_t element);
     static G1Element FromMessage(const std::vector<uint8_t> &message,
                                  const uint8_t *dst,
@@ -54,7 +54,7 @@ public:
     void ToNative(g1_t output) const;
     G1Element Negate() const;
     uint32_t GetFingerprint() const;
-    std::vector<uint8_t> Serialize() const;
+    std::vector<uint8_t> Serialize(bool fLegacy = false) const;
 
     friend bool operator==(const G1Element &a, const G1Element &b);
     friend bool operator!=(const G1Element &a, const G1Element &b);
@@ -76,21 +76,23 @@ public:
         g2_set_infty(q);
     }
 
-    static G2Element FromBytes(const Bytes& bytes);
-    static G2Element FromByteVector(const std::vector<uint8_t> &bytevec);
+    static G2Element FromBytes(const Bytes& bytes, bool fLegacy = false);
+    static G2Element FromByteVector(const std::vector<uint8_t> &bytevec, bool fLegacy = false);
     static G2Element FromNative(const g2_t element);
     static G2Element FromMessage(const std::vector<uint8_t>& message,
                                  const uint8_t* dst,
-                                 int dst_len);
+                                 int dst_len,
+                                 bool fLegacy = false);
     static G2Element FromMessage(const Bytes& message,
                                  const uint8_t* dst,
-                                 int dst_len);
+                                 int dst_len,
+                                 bool fLegacy = false);
     static G2Element Generator();
 
     void CheckValid() const;
     void ToNative(g2_t output) const;
     G2Element Negate() const;
-    std::vector<uint8_t> Serialize() const;
+    std::vector<uint8_t> Serialize(bool fLegacy = false) const;
 
     friend bool operator==(G2Element const &a, G2Element const &b);
     friend bool operator!=(G2Element const &a, G2Element const &b);

--- a/src/legacy.cpp
+++ b/src/legacy.cpp
@@ -1,0 +1,433 @@
+// Copyright (c) 2021 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "legacy.hpp"
+
+#define B12_P381_S3 "BE32CE5FBEED9CA374D38C0ED41EEFD5BB675277CDF12D11BC2FB026C41400045C03FFFFFFFDFFFD"
+#define B12_P381_S32 "5F19672FDF76CE51BA69C6076A0F77EADDB3A93BE6F89688DE17D813620A00022E01FFFFFFFEFFFE"
+
+/**
+ * Returns the (sqrt(-3) - 1) / 2 mod q in the curve, where q is the prime.
+ *
+ * @param[out] h			- the returned cofactor.
+ */
+static void ep2_curve_get_s32(bn_t s32In) {
+    static bool fInitialized{false};
+    static bn_t s32;
+    if (!fInitialized) {
+        bn_new(s32);
+        bn_read_str(s32, B12_P381_S32, sizeof(B12_P381_S32), 16);
+        fInitialized = true;
+    }
+    bn_copy(s32In, s32);
+}
+
+/**
+ * Returns the sqrt(-3) mod q in the curve, where q is the prime.
+ *
+ * @param[out] h			- the returned cofactor.
+ */
+static void ep2_curve_get_s3(bn_t s3In) {
+    static bool fInitialized{false};
+    static bn_t s3;
+    if (!fInitialized) {
+        bn_new(s3);
+        bn_read_str(s3, B12_P381_S3, sizeof(B12_P381_S3), 16);
+        fInitialized = true;
+    }
+    bn_copy(s3In, s3);
+}
+
+/**
+ * Returns the 'b' coefficient of the currently configured elliptic curve.
+ *
+ * @param[out] b			- the 'b' coefficient of the elliptic curve.
+ */
+static void ep2_curve_get_b(fp2_t b) {
+    ctx_t *ctx = core_get();
+    fp_copy(b[0], ctx->ep2_b[0]);
+    fp_copy(b[1], ctx->ep2_b[1]);
+}
+
+/**
+ * Returns the variable used to parameterize the given prime modulus.
+ *
+ * @param[out] x			- the integer parameter.
+ */
+static void fp_param_get_var(bn_t x) {
+    bn_t a;
+
+    bn_null(a);
+
+    RLC_TRY {
+            bn_new(a);
+            /* x = -(2^63 + 2^62 + 2^60 + 2^57 + 2^48 + 2^16). */
+            bn_set_2b(x, 63);
+            bn_set_2b(a, 62);
+            bn_add(x, x, a);
+            bn_set_2b(a, 60);
+            bn_add(x, x, a);
+            bn_set_2b(a, 57);
+            bn_add(x, x, a);
+            bn_set_2b(a, 48);
+            bn_add(x, x, a);
+            bn_set_2b(a, 16);
+            bn_add(x, x, a);
+            bn_neg(x, x);
+    }
+    RLC_CATCH_ANY {
+            RLC_THROW(ERR_CAUGHT);
+    }
+    RLC_FINALLY {
+            bn_free(a);
+    }
+}
+
+/**
+ * Multiplies a point by the cofactor in a Barreto-Lynn-Soctt.
+ *
+ * @param[out] r			- the result.
+ * @param[in] p				- the point to multiply.
+ */
+static void ep2_mul_cof_b12(ep2_t r, ep2_t p) {
+    bn_t x;
+    ep2_t t0, t1, t2, t3;
+
+    ep2_null(t0);
+    ep2_null(t1);
+    ep2_null(t2);
+    ep2_null(t3);
+    bn_null(x);
+
+    RLC_TRY {
+            ep2_new(t0);
+            ep2_new(t1);
+            ep2_new(t2);
+            ep2_new(t3);
+            bn_new(x);
+
+            fp_param_get_var(x);
+
+            /* Compute t0 = xP. */
+            ep2_mul_basic(t0, p, x);
+            /* Compute t1 = [x^2]P. */
+            ep2_mul_basic(t1, t0, x);
+
+            /* t2 = (x^2 - x - 1)P = x^2P - x*P - P. */
+            ep2_sub(t2, t1, t0);
+            ep2_sub(t2, t2, p);
+            /* t3 = \psi(x - 1)P. */
+            ep2_sub(t3, t0, p);
+            ep2_norm(t3, t3);
+            ep2_frb(t3, t3, 1);
+            ep2_add(t2, t2, t3);
+            /* t3 = \psi^2(2P). */
+            ep2_dbl(t3, p);
+            ep2_norm(t3, t3);
+            ep2_frb(t3, t3, 2);
+            ep2_add(t2, t2, t3);
+            ep2_norm(r, t2);
+    }
+    RLC_CATCH_ANY {
+            RLC_THROW(ERR_CAUGHT);
+    }
+    RLC_FINALLY {
+            ep2_free(t0);
+            ep2_free(t1);
+            ep2_free(t2);
+            ep2_free(t3);
+            bn_free(x);
+    }
+}
+
+/**
+ * Based on the rust implementation of pairings, zkcrypto/pairing.
+ * The algorithm is Shallue–van de Woestijne encoding from
+ * Section 3 of "Indifferentiable Hashing to Barreto–Naehrig Curves"
+ * from Fouque-Tibouchi: <https://www.di.ens.fr/~fouque/pub/latincrypt12.pdf>
+ */
+static void ep2_sw_encode(ep2_t p, fp2_t t) {
+    if (fp2_is_zero(t)) {
+        // Maps t=0 to the point at infinity.
+        ep2_set_infty(p);
+        return;
+    }
+    fp2_t nt; // Negative t
+    fp2_t w;
+    fp2_t b;
+    bn_t s_n3;
+    bn_t s_n3m1o2;
+    fp2_t x1;
+    fp2_t x2;
+    fp2_t x3;
+    fp2_t rhs;
+
+    fp2_new(nt);
+    fp2_new(w);
+    fp2_new(b);
+    bn_new(s_n3);
+    bn_new(s_n3m1o2);
+    fp2_new(x1);
+    fp2_new(x2);
+    fp2_new(x3);
+    fp2_new(rhs);
+
+    // nt = -t
+    fp2_neg(nt, t);
+
+    uint8_t buf0[RLC_FP_BYTES];  // t[1]
+    uint8_t buf1[RLC_FP_BYTES];  // -t[1]
+    fp_write_bin(buf0, RLC_FP_BYTES, t[1]);
+    fp_write_bin(buf1, RLC_FP_BYTES, nt[1]);
+
+    // Compare bytes since fp_cmp compares montgomery representation
+    int parity = memcmp(buf0, buf1, RLC_FP_BYTES) > 0;
+
+    // w = t^2 + b + 1
+    fp2_mul(w, t, t);
+    ep2_curve_get_b(b);
+    fp2_add(w, w, b);
+    fp_add_dig(w[0], w[0], 1);
+
+    if (fp2_is_zero(w)) {
+        ep2_curve_get_gen(p);
+        if (parity) {
+            ep2_neg(p, p);
+        }
+        fp2_free(nt);
+        fp2_free(w);
+        fp2_free(b);
+        bn_free(s_n3);
+        bn_free(s_n3m1o2);
+        fp2_free(x1);
+        fp2_free(x2);
+        fp2_free(x3);
+        fp2_free(rhs);
+        return;
+    }
+
+    // sqrt(-3)
+    ep2_curve_get_s3(s_n3);
+    fp2_t s_n3p;
+    fp2_null(s_n3p);
+    fp2_new(s_n3p);
+    fp2_t s_n3m1o2p;
+    fp2_null(s_n3m1o2p);
+    fp2_new(s_n3m1o2p);
+
+    fp2_zero(s_n3p);
+    fp2_zero(s_n3m1o2p);
+    fp_prime_conv(s_n3p[0], s_n3);
+
+    // (sqrt(-3) - 1) / 2
+    ep2_curve_get_s32(s_n3m1o2);
+    fp_prime_conv(s_n3m1o2p[0], s_n3m1o2);
+
+    fp2_inv(w, w);
+    fp2_mul(w, w, s_n3p);
+    fp2_mul(w, w, t);
+
+    // x1 = -wt + sqrt(-3)
+    fp2_neg(x1, w);
+    fp2_mul(x1, x1, t);
+    fp2_add(x1, x1, s_n3m1o2p);
+
+    // x2 = -x1 - 1
+    fp2_neg(x2, x1);
+    fp_sub_dig(x2[0], x2[0], 1);
+
+    // x3 = 1/w^2 + 1
+    fp2_mul(x3, w, w);
+    fp2_inv(x3, x3);
+    fp_add_dig(x3[0], x3[0], 1);
+
+    fp2_zero(p->y);
+    fp2_set_dig(p->z, 1);
+
+    // if x1 has no y, try x2. if x2 has no y, try x3
+    fp2_copy(p->x, x1);
+
+    ep2_rhs(rhs, p);
+    int Xx1 = fp2_srt(p->y, rhs) ? 1 : -1;
+    fp2_copy(p->x, x2);
+    ep2_rhs(rhs, p);
+    int Xx2 = fp2_srt(p->y, rhs) ? 1 : -1;
+
+    // This formula computes which index to use, in constant time
+    // without conditional branches. It's taken from the paper. 3 is
+    // added, because the % operator in c can be negative.
+    int index = ((((Xx1 - 1) * Xx2) % 3) + 3) % 3;
+
+    if (index == 0) {
+        fp2_copy(p->x, x1);
+        ep2_rhs(rhs, p);
+        fp2_srt(p->y, rhs);
+    } else if (index == 1) {
+        fp2_copy(p->x, x2);
+        ep2_rhs(rhs, p);
+        fp2_srt(p->y, rhs);
+    } else if (index == 2) {
+        fp2_copy(p->x, x3);
+        ep2_rhs(rhs, p);
+        fp2_srt(p->y, rhs);
+    }
+
+    p->coord = 1;
+
+    // Check for lexicografically greater than the negation
+    fp2_t ny;
+    fp2_null(ny);
+    fp2_new(ny);
+    fp2_neg(ny, p->y);
+    fp_write_bin(buf0, RLC_FP_BYTES, p->y[1]);
+    fp_write_bin(buf1, RLC_FP_BYTES, ny[1]);
+
+    // Compare bytes since fp_cmp compares montgomery representation
+    if ((memcmp(buf0, buf1, RLC_FP_BYTES) > 0) != parity) {
+        ep2_neg(p, p);
+    }
+
+    fp2_free(nt);
+    fp2_free(w);
+    fp2_free(b);
+    bn_free(s_n3);
+    bn_free(s_n3m1o2);
+    fp2_free(x1);
+    fp2_free(x2);
+    fp2_free(x3);
+    fp2_free(rhs);
+
+    fp2_free(s_n3p);
+    fp2_free(s_n3m1o2p);
+    fp2_free(ny);
+}
+
+void ep2_map_legacy(ep2_t p, const uint8_t *msg, int len) {
+    bn_t t00;
+    bn_t t01;
+    bn_t t10;
+    bn_t t11;
+    fp_t t00p;
+    fp_t t01p;
+    fp_t t10p;
+    fp_t t11p;
+    fp2_t t0p;
+    fp2_t t1p;
+    ep2_t p0;
+    ep2_t p1;
+
+    bn_null(t00);
+    bn_null(t01);
+    bn_null(t10);
+    bn_null(t11);
+    fp_null(t00p);
+    fp_null(t01p);
+    fp_null(t10p);
+    fp_null(t11p);
+    fp2_null(t0p);
+    fp2_null(t1p);
+    ep2_null(p1);
+    ep2_null(p0);
+
+    RLC_TRY {
+            uint8_t input[RLC_MD_LEN + 8];
+            if (len != RLC_MD_LEN) {
+                RLC_THROW(ERR_CAUGHT);
+            }
+            memcpy(input, msg, len);
+            // b"G2_0_c0"
+            input[RLC_MD_LEN + 0] = 0x47; // G
+            input[RLC_MD_LEN + 1] = 0x32; // 2
+            input[RLC_MD_LEN + 2] = 0x5f; // _
+            input[RLC_MD_LEN + 3] = 0x30; // 0
+            input[RLC_MD_LEN + 4] = 0x5f; // _
+            input[RLC_MD_LEN + 5] = 0x63; // c
+            input[RLC_MD_LEN + 6] = 0x30; // 0
+
+            bn_new(t00);
+            bn_new(t01);
+            bn_new(t10);
+            bn_new(t11);
+            fp_new(t00p);
+            fp_new(t01p);
+            fp_new(t10p);
+            fp_new(t11p);
+            fp2_new(t0p);
+            fp2_new(t1p);
+            ep2_new(p1);
+            ep2_new(p0);
+
+            uint8_t t00Bytes[RLC_MD_LEN * 2];
+            uint8_t t01Bytes[RLC_MD_LEN * 2];
+            uint8_t t10Bytes[RLC_MD_LEN * 2];
+            uint8_t t11Bytes[RLC_MD_LEN * 2];
+
+            // b"G2_0_c0"
+            input[RLC_MD_LEN + 7] = 0x00; // 0
+            md_map(t00Bytes, input, RLC_MD_LEN + 8);
+            input[RLC_MD_LEN + 7] = 1;    // 1
+            md_map(t00Bytes + RLC_MD_LEN, input, RLC_MD_LEN + 8);
+
+            // b"G2_0_c1"
+            input[RLC_MD_LEN + 6] = 0x31; // b"1"
+            input[RLC_MD_LEN + 7] = 0;    // 0
+
+            md_map(t01Bytes, input, RLC_MD_LEN + 8);
+            input[RLC_MD_LEN + 7] = 1;    // 1
+            md_map(t01Bytes + RLC_MD_LEN, input, RLC_MD_LEN + 8);
+
+            // b"G2_1_c0"
+            input[RLC_MD_LEN + 3] = 0x31;  // b"1"
+            input[RLC_MD_LEN + 6] = 0x30;  // b"0"
+            input[RLC_MD_LEN + 7] = 0;     // 0
+            md_map(t10Bytes, input, RLC_MD_LEN + 8);
+            input[RLC_MD_LEN + 7] = 1;     // 1
+            md_map(t10Bytes + RLC_MD_LEN, input, RLC_MD_LEN + 8);
+
+            // b"G2_1_c1"
+            input[RLC_MD_LEN + 6] = 0x31;     // b"1"
+            input[RLC_MD_LEN + 7] = 0;     // 0
+            md_map(t11Bytes, input, RLC_MD_LEN + 8);
+            input[RLC_MD_LEN + 7] = 1;     // 1
+            md_map(t11Bytes + RLC_MD_LEN, input, RLC_MD_LEN + 8);
+
+            bn_read_bin(t00, t00Bytes, RLC_MD_LEN * 2);
+            bn_read_bin(t01, t01Bytes, RLC_MD_LEN * 2);
+            bn_read_bin(t10, t10Bytes, RLC_MD_LEN * 2);
+            bn_read_bin(t11, t11Bytes, RLC_MD_LEN * 2);
+
+            fp_prime_conv(t00p, t00);
+            fp_prime_conv(t01p, t01);
+            fp_prime_conv(t10p, t10);
+            fp_prime_conv(t11p, t11);
+
+            fp_copy(t0p[0], t00p);
+            fp_copy(t0p[1], t01p);
+            fp_copy(t1p[0], t10p);
+            fp_copy(t1p[1], t11p);
+
+            ep2_sw_encode(p0, t0p);
+            ep2_sw_encode(p1, t1p);
+            ep2_add(p0, p0, p1);
+            /* Now, multiply by cofactor to get the correct group. */
+            ep2_mul_cof_b12(p, p0);
+    }
+    RLC_CATCH_ANY {
+            RLC_THROW(ERR_CAUGHT);
+    }
+    RLC_FINALLY {
+            fp2_free(t0p);
+            fp2_free(t1p);
+            fp_free(t00p);
+            fp_free(t01p);
+            fp_free(t10p);
+            fp_free(t11p);
+            bn_free(t00);
+            bn_free(t01);
+            bn_free(t10);
+            bn_free(t11);
+            ep2_free(p0);
+            ep2_free(p1);
+    }
+}

--- a/src/legacy.hpp
+++ b/src/legacy.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef SRC_LEGACY_HPP_
+#define SRC_LEGACY_HPP_
+
+#include <ios>
+
+#include "relic_conf.h"
+
+#if defined GMP && ARITH == GMP
+#include <gmp.h>
+#endif
+
+extern "C" {
+#include "relic.h"
+}
+
+/**
+ * Maps a byte array to a point in an elliptic curve over a quadratic extension.
+ *
+ * Called ep2_map() in old relic version, _legacy prefix is to avoid duplicated symbols
+ *
+ * @param[out] p			- the result.
+ * @param[in] msg			- the byte array to map.
+ * @param[in] len			- the array length in bytes.
+ */
+void ep2_map_legacy(ep2_t p, const uint8_t *msg, int len);
+
+#endif  // #define SRC_LEGACY_HPP_

--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -154,6 +154,21 @@ G2Element operator*(const G2Element &a, const PrivateKey &k)
 
 G2Element operator*(const PrivateKey &k, const G2Element &a) { return a * k; }
 
+PrivateKey operator*(const PrivateKey& k, const bn_t& a)
+{
+    k.CheckKeyData();
+    bn_t order;
+    bn_new(order);
+    g2_get_ord(order);
+
+    PrivateKey ret;
+    bn_mul_comba(ret.keydata, k.keydata, a);
+    bn_mod_basic(ret.keydata, ret.keydata, order);
+    return ret;
+}
+
+PrivateKey operator*(const bn_t& a, const PrivateKey& k) { return a * k; }
+
 G2Element PrivateKey::GetG2Power(const G2Element& element) const
 {
     CheckKeyData();

--- a/src/privatekey.hpp
+++ b/src/privatekey.hpp
@@ -40,6 +40,8 @@ class PrivateKey {
     // Aggregate many private keys into one (sum of keys mod order)
     static PrivateKey Aggregate(std::vector<PrivateKey> const &privateKeys);
 
+    PrivateKey();
+
     // Construct a private key from another private key. Allocates memory in
     // secure heap, and copies keydata.
     PrivateKey(const PrivateKey &k);
@@ -79,8 +81,6 @@ class PrivateKey {
         size_t dst_len) const;
     
  private:
-    // Don't allow public construction, force static methods
-    PrivateKey();
 
     // Allocate memory for private key
     void AllocateKeyData();

--- a/src/privatekey.hpp
+++ b/src/privatekey.hpp
@@ -70,6 +70,9 @@ class PrivateKey {
     friend G2Element operator*(const G2Element &a, const PrivateKey &k);
     friend G2Element operator*(const PrivateKey &k, const G2Element &a);
 
+    friend PrivateKey operator*(const PrivateKey& a, const bn_t& k);
+    friend PrivateKey operator*(const bn_t& k, const PrivateKey& a);
+
     // Serialize the key into bytes
     void Serialize(uint8_t *buffer) const;
     std::vector<uint8_t> Serialize(bool fLegacy = false) const;

--- a/src/privatekey.hpp
+++ b/src/privatekey.hpp
@@ -72,13 +72,14 @@ class PrivateKey {
 
     // Serialize the key into bytes
     void Serialize(uint8_t *buffer) const;
-    std::vector<uint8_t> Serialize() const;
+    std::vector<uint8_t> Serialize(bool fLegacy = false) const;
 
     G2Element SignG2(
         const uint8_t *msg,
         size_t len,
         const uint8_t *dst,
-        size_t dst_len) const;
+        size_t dst_len,
+        bool fLegacy = false) const;
     
  private:
 

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -25,6 +25,35 @@ using std::vector;
 
 namespace bls {
 
+static void HashPubKeys(bn_t* computedTs, std::vector<Bytes> vecPubKeyBytes)
+{
+    bn_t order;
+    bn_new(order);
+    g2_get_ord(order);
+
+    std::vector<uint8_t> vecBuffer(vecPubKeyBytes.size() * G1Element::SIZE);
+
+    for (size_t i = 0; i < vecPubKeyBytes.size(); i++) {
+        memcpy(vecBuffer.data() + i * G1Element::SIZE, vecPubKeyBytes[i].begin(), G1Element::SIZE);
+    }
+
+    uint8_t pkHash[32];
+    Util::Hash256(pkHash, vecBuffer.data(), vecPubKeyBytes.size() * G1Element::SIZE);
+    for (size_t i = 0; i < vecPubKeyBytes.size(); ++i) {
+        uint8_t hash[32];
+        uint8_t buffer[4 + 32];
+        memset(buffer, 0, 4);
+        // Set first 4 bytes to index, to generate different ts
+        Util::IntToFourBytes(buffer, i);
+        // Set next 32 bytes as the hash of all the public keys
+        std::memcpy(buffer + 4, pkHash, 32);
+        Util::Hash256(hash, buffer, 4 + 32);
+
+        bn_read_bin(computedTs[i], hash, 32);
+        bn_mod_basic(computedTs[i], computedTs[i], order);
+    }
+}
+
 enum InvariantResult { BAD=false, GOOD=true, CONTINUE };
 
 // Enforce argument invariants for Agg Sig Verification
@@ -148,6 +177,92 @@ G1Element CoreMPL::Aggregate(const vector<G1Element> &publicKeys)
         aggregated += publicKey;
     }
     return aggregated;
+}
+
+G2Element CoreMPL::AggregateSecure(std::vector<G1Element> const &vecPublicKeys,
+                                   std::vector<G2Element> const &vecSignatures,
+                                   const Bytes& message,
+                                   const bool fLegacy) {
+    if (vecSignatures.size() != vecPublicKeys.size()) {
+        throw std::invalid_argument("LegacySchemeMPL::AggregateSigs sigs.size() != pubKeys.size()");
+    }
+
+    bn_t* computedTs = new bn_t[vecPublicKeys.size()];
+    std::vector<std::pair<vector<uint8_t>, const G2Element*>> vecSorted(vecPublicKeys.size());
+    for (size_t i = 0; i < vecPublicKeys.size(); i++) {
+        bn_new(computedTs[i]);
+        vecSorted[i] = std::make_pair(vecPublicKeys[i].Serialize(fLegacy), &vecSignatures[i]);
+    }
+    std::sort(vecSorted.begin(), vecSorted.end(), [](const auto& a, const auto& b) {
+        return std::memcmp(a.first.data(), b.first.data(), G1Element::SIZE) < 0;
+    });
+
+    std::vector<Bytes> vecPublicKeyBytes;
+    vecPublicKeyBytes.reserve(vecPublicKeys.size());
+    for (const auto& it : vecSorted) {
+        vecPublicKeyBytes.push_back(Bytes{it.first});
+    }
+
+    HashPubKeys(computedTs, vecPublicKeyBytes);
+
+    // Raise all signatures to power of the corresponding t's and aggregate the results into aggSig
+    // Also accumulates aggregation info for each signature
+    std::vector<G2Element> expSigs;
+    expSigs.reserve(vecSorted.size());
+    for (size_t i = 0; i < vecSorted.size(); i++) {
+        expSigs.emplace_back(*vecSorted[i].second * computedTs[i]);
+    }
+
+    G2Element aggSig = CoreMPL::Aggregate(expSigs);
+
+    delete[] computedTs;
+
+    return aggSig;
+}
+
+G2Element CoreMPL::AggregateSecure(std::vector<G1Element> const &vecPublicKeys,
+                                   std::vector<G2Element> const &vecSignatures,
+                                   const Bytes& message) {
+    return CoreMPL::AggregateSecure(vecPublicKeys, vecSignatures, message, false);
+}
+
+bool CoreMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
+                           const G2Element& signature,
+                           const Bytes& message,
+                           const bool fLegacy) {
+    bn_t one;
+    bn_new(one);
+    bn_zero(one);
+    bn_set_dig(one, 1);
+
+    bn_t* computedTs = new bn_t[vecPublicKeys.size()];
+    std::vector<vector<uint8_t>> vecSorted(vecPublicKeys.size());
+    for (size_t i = 0; i < vecPublicKeys.size(); i++) {
+        bn_new(computedTs[i]);
+        vecSorted[i] = vecPublicKeys[i].Serialize(fLegacy);
+    }
+    std::sort(vecSorted.begin(), vecSorted.end(), [](const auto& a, const auto& b) -> bool {
+        return std::memcmp(a.data(), b.data(), G1Element::SIZE) < 0;
+    });
+
+    HashPubKeys(computedTs, {vecSorted.begin(), vecSorted.end()});
+
+    G1Element publicKey;
+    for (size_t i = 0; i < vecSorted.size(); ++i) {
+        G1Element g1 = G1Element::FromBytes(Bytes(vecSorted[i]), fLegacy);
+        publicKey = CoreMPL::Aggregate({publicKey, g1 * computedTs[i]});
+    }
+
+    bn_free(one);
+    delete[] computedTs;
+
+    return AggregateVerify({publicKey}, {message}, {signature});
+}
+
+bool CoreMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
+                           const G2Element& signature,
+                           const Bytes& message) {
+    return CoreMPL::VerifySecure(vecPublicKeys, signature, message, false);
 }
 
 bool CoreMPL::AggregateVerify(const vector<vector<uint8_t>> &pubkeys,

--- a/src/schemes.hpp
+++ b/src/schemes.hpp
@@ -71,6 +71,14 @@ public:
 
     virtual G1Element Aggregate(const vector<G1Element> &publicKeys);
 
+    virtual G2Element AggregateSecure(const std::vector<G1Element>& vecPublicKeys,
+                                      const std::vector<G2Element>& vecSignatures,
+                                      const Bytes& message);
+
+    virtual bool VerifySecure(const std::vector<G1Element>& vecPublicKeys,
+                              const G2Element& signature,
+                              const Bytes& message);
+
     virtual bool AggregateVerify(const vector<vector<uint8_t>> &pubkeys,
                                  const vector<vector<uint8_t>> &messages,
                                  const vector<uint8_t> &signature);
@@ -94,6 +102,14 @@ public:
 protected:
     const std::string& strCiphersuiteId;
     bool NativeVerify(g1_t *pubKeys, g2_t *mappedHashes, size_t length);
+    G2Element AggregateSecure(std::vector<G1Element> const &vecPublicKeys,
+                              std::vector<G2Element> const &vecSignatures,
+                              const Bytes& message,
+                              bool fLegacy);
+    bool VerifySecure(const std::vector<G1Element>& vecPublicKeys,
+                      const G2Element& signature,
+                      const Bytes& message,
+                      bool fLegacy);
 };
 
 class BasicSchemeMPL : public CoreMPL {

--- a/src/schemes.hpp
+++ b/src/schemes.hpp
@@ -218,6 +218,56 @@ public:
                              const Bytes& signature);
 };
 
+/**
+ * This scheme reflects the Sign/Verify behaviour of older bls-signatures library versions (<0.1.29).
+ */
+class LegacySchemeMPL : public CoreMPL {
+
+public:
+    LegacySchemeMPL() : CoreMPL(std::string{}) {}
+
+    virtual vector<uint8_t> SkToPk(const PrivateKey &seckey) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+
+    G2Element Sign(const PrivateKey &seckey, const vector<uint8_t> &message) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+    G2Element Sign(const PrivateKey &seckey, const Bytes& message) final;
+
+    bool Verify(const vector<uint8_t>& pubkey,
+                const vector<uint8_t>& message,
+                const vector<uint8_t>& signature) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+
+    bool Verify(const G1Element& pubkey,
+                const vector<uint8_t>& message,
+                const G2Element& signature) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+
+    bool Verify(const Bytes& pubkey, const Bytes& message, const Bytes& signature) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+    bool Verify(const G1Element &pubkey, const Bytes& message, const G2Element &signature) final;
+
+    vector<uint8_t> Aggregate(const vector<vector<uint8_t>> &signatures) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+
+    G2Element AggregateSecure(const std::vector<G1Element>& vecPublicKeys,
+                              const std::vector<G2Element>& vecSignatures,
+                              const Bytes& message) final;
+
+    bool VerifySecure(const std::vector<G1Element>& vecPublicKeys,
+                      const G2Element& signature,
+                      const Bytes& message) final;
+
+    bool AggregateVerify(const vector<vector<uint8_t>> &pubkeys,
+                         const vector<vector<uint8_t>> &messages,
+                         const vector<uint8_t> &signature) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+
+    bool AggregateVerify(const vector<Bytes> &pubkeys,
+                         const vector<Bytes> &messages,
+                         const Bytes &signature) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+
+    bool AggregateVerify(const vector<G1Element> &pubkeys,
+                         const vector<vector<uint8_t>> &messages,
+                         const G2Element &signature) final { throw std::runtime_error("Not supported in LegacySchemeMPL"); }
+
+    bool AggregateVerify(const vector<G1Element> &pubkeys,
+                         const vector<Bytes> &messages,
+                         const G2Element &signature) final;
+};
 }  // end namespace bls
 
 #endif  // SRC_BLSSCHEMES_HPP_

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1167,6 +1167,157 @@ TEST_CASE("Schemes") {
         REQUIRE(PopSchemeMPL().FastAggregateVerify(
             {pk1v, pk2v}, msg1, aggsigv_same));
     }
+
+    SECTION("Legacy scheme") {
+        // Test legacy example data defined in https://gist.github.com/xdustinface/318c2c08c36ab12a2b1963caf1f7815c
+        std::string strSignHash{"b6d8ee31bbd375dfd55d5fb4b02cfccc68709e64f4c5ffcd3895ceb46540311d"};
+        std::string strThresholdPublicKey{"97a12b918eac73718d55b7fca60435ec0b442d7e24b45cbd80f5cf2ea2e14c4164333fffdb00d27e309abbafacaa9c34"};
+        std::string strThresholdSignature{"031c536960c9c44efefa4a3334d2d1b808f46abe121cd14a1d0b6ee6b6dca85fd3087d86fe5b1327e6792be53f4ed4df19c3af3aac79c0bb9dc36fc2a30ba566de6a82cd3e4af2d6654cbe02bb52769a06c1644a4c63b3c3a6fd16e5e68e5c0b"};
+        std::vector<std::string> vecSecretKeySharesHex{
+            "43dd263542a8d10bc9f843b46f15c86cd87e00c8f45fe5339b30c08e3233d8e3",
+            "5e7247ef1a0e671b8349e7be3f50ec88f1eafde90345f34520010e4aa9f18731",
+            "34bcc40dea17bb03ec085ac46a0ea9614b3ffc4bae8b0b292f3d7c54662b00a6",
+            "139f967b6f4af5dfe2bebf8085b6332efe31c2dc348d02e6b4745a0e7e56a469",
+            "08442e959054d87b5de3553ef8cfd9da923241664c35c6548b5e3271a86b4a18",
+            "2698613947a156639b423ad1a9fbe45863d58540d8ebd08612504bf9cf4743ea",
+            "1871c9270c8344028946eee64e79d09e4915dd3b717ffc1c9aa86faff88c0475",
+            "68409938427df3567e8948c1fff8610b5cf94872eb959c90a714b7ff0f339e88",
+            "70d3e3ad7d22bd30e4e2ca108a3fa47f4873bda28f3b000a218339b09db6f58a",
+            "39ea630e894b71d9f28fefb551611824f16d4b16d29fdea8bb3dbd857a6bc317",
+        };
+        std::vector<std::string> vecSigSharesHex{
+                "0888879c99852460912fd28c7a9138926c1e87fd6609fd2d3d307764e49feb85702fd8f9b3b836bc11f7ce151b769dc70b760879d26f8c33a29e24f69297f45ef028f0794e63ddb0610db7de1a608b6d6a2129ada62b845004a408f651fd44a5",
+                "16efc39fa5aa979245a82334856a97ebf3027bc6be7d35df117267a3c9b1618e32477fe1b8f4a23bdba346bf2b2b35ad0b395227de76827fd32eb9952e0d97b7dba275040101131a7fc38ea381a3099c2b3205177866ee4ab3119593bb58d092",
+                "8407afd2776ab9d3f9293f1519ace1a9ce8aaf07d0a6a9785ec7ae4ae47e42102c09cfb3c8655dba014d53933af6a0b41244df006575e85e333271c90fcad80410cab4962bf4bba1570770775b1282f142b526d521a38fbc14336f22dc44a683",
+                "027061a8c2d631e40882ce6919d3e5f45c4c74ac32a3bce94e5661d06cdecf2d492dfab99e9a9dd8a29a90fe8f816be30178bf9277a3751882e49bb9f08437f5f2cd9dbc12c2fdcccaf7578838e87273fd2ba87f20cf00ca5fec56822f845769",
+                "178ece91967145b1dfc02de703dbd8049b05d626f18a71303ea0c23ee3b60a52bd61cc30fea3e4a562b20c20e0439a2f108b4e6b8a646f647afb64e3b355eba382380ef2c634f3a56de066b7a764249aba1c42c49d76d65e094e890cbbf005a3",
+                "193da45d31d728acc92165173253fd8689301b448c81039350ae6916a72f157b00da469a7ab6d2b5db2dac216f47073d089afdcdffce25b6aac991f4745c803f164d7426b8da7d19bf699f5e5489f715ac32e539db90610d7df47121556c1a20",
+                "938ce6cc265fa15fe67314ac4773f18ff0b49c01eac626814abc2f836814068aeba8582d619a3e0c08dc4bafecda84a818b6a7abd350637e72a47356e5919e3a72be66316417c598338e4ab85f8d25535bd6c4a5fb16767ac470902e0cf19df0",
+                "985039d55a92f6fb3b324b0b9f1c7ddcd5f443d6d1ce72549f043b967ded7d56dc4320dc8569a1c41c6cfb4c150d8c61095d3b325e3308a321ceb43369fe56807fba67b6b313f072ab2cdbaa872b52a9a2e75bf396f1b2007152067f756946b7",
+                "922717d8c170862662d08a4c29943cc26bb05daff0f07b0b7c352651ec64ee5a1d032bad24dfb42243e9afe044ed25680694b183b657948a91533e9a73b6bf359ff907d5088503137edc8e271ac3d2003a4daf8d36f3f847cc87afc6f9007c72",
+                "02bc8e3ea8409418949fb4106e00893b49983495035b47026a1747eb6f89b05d4c1b8e357e89ddfa7c9f8145b78e0c480177842f20b98b1f7ca2ed26cfb9895380e4d86aeb60c2326bc43753a0633167a7c4ae7a526ce927ade1388a6cdc11d1",
+        };
+        std::vector<std::string> vecIdsHex{
+                "4393e2a243c3db776dcdbe2535493440d29cb65006a1e6f0f8d3f1e1488cbf1a",
+                "8b2d776ac75cfca1559b5616ade4eb376a6478556135276e4b3210fe170b9f59",
+                "f2015bdbc0daa70c41a25d2450b96f433ac7d568126505e9997794bb357cf3af",
+                "5818a68f2f34e5ff7d1d43beca5ff103739dd918efda4bac7fd4ede6c53dc6af",
+                "965437bdf51278f716078477a2eae595a9d2b0aa3fe69a387b30936c13c7d68e",
+                "fd14695a48a35fe6a1f9894accfa83349508e350b3f743d494074fe204b17166",
+                "7e3c28e59ff54bf097b2f3ada4a30f5613227951116675127fc97c98405f2067",
+                "5e427dba092e3d81d057c0277a9a465e036c8336c59a18f27d7c21bc51910904",
+                "90976dbe492de3eda7623c7ad6523ed9f63f83c3200c383fccd9f22408e18e1b",
+                "cd474447afd5df18a0c10c9e2d5216eace9c624119974280236a043cb4b7f8ae",
+        };
+        size_t nSize = 10;
+        REQUIRE(vecSecretKeySharesHex.size() == nSize);
+        REQUIRE(vecSigSharesHex.size() == nSize);
+        REQUIRE(vecIdsHex.size() == nSize);
+
+        std::vector<uint8_t> vecSignHash = Util::HexToBytes(strSignHash);
+        std::reverse(vecSignHash.begin(), vecSignHash.end());
+        G1Element thresholdPublicKey = G1Element::FromByteVector(Util::HexToBytes(strThresholdPublicKey), true);
+        G2Element thresholdSignatureExpected = G2Element::FromByteVector(Util::HexToBytes(strThresholdSignature), true);
+
+        std::vector<G2Element> vecSignatureShares;
+        std::vector<std::vector<uint8_t>> vecIds;
+
+        for (size_t i = 0; i < nSize; ++i) {
+            vecIds.push_back(Util::HexToBytes(vecIdsHex[i]));
+            std::reverse(vecIds.back().begin(), vecIds.back().end());
+
+            PrivateKey skShare = PrivateKey::FromByteVector(Util::HexToBytes(vecSecretKeySharesHex[i]));
+            std::vector<uint8_t> vecSigShareBytes = Util::HexToBytes(vecSigSharesHex[i]);
+            vecSignatureShares.push_back(G2Element::FromByteVector(vecSigShareBytes, true));
+            G2Element sigShare = LegacySchemeMPL().Sign(skShare, Bytes(vecSignHash));
+            REQUIRE(sigShare == vecSignatureShares.back());
+            REQUIRE(sigShare.Serialize(true) == vecSigShareBytes);
+        }
+
+        G2Element thresholdSignature = Threshold::SignatureRecover(vecSignatureShares, {vecIds.begin(), vecIds.end()});
+        REQUIRE(thresholdSignature == thresholdSignatureExpected);
+        REQUIRE(LegacySchemeMPL().Verify(thresholdPublicKey, Bytes{vecSignHash}, thresholdSignature));
+    }
+}
+
+TEST_CASE("Threshold Signatures") {
+    SECTION("Secret Key Shares") {
+        size_t m = 3;
+        size_t n = 5;
+
+        std::vector<PrivateKey> sks;
+        std::vector<G1Element> pks;
+        std::vector<G2Element> sigs;
+        std::vector<std::vector<uint8_t>> idHashes(n);
+        std::vector<Bytes> ids;
+        std::vector<PrivateKey> skShares;
+        std::vector<G1Element> pkShares;
+        std::vector<G2Element> sigShares;
+
+        std::vector<uint8_t> vecHash = getRandomSeed();
+
+        for (size_t i = 0; i < n; i++) {
+            idHashes[i] = getRandomSeed();
+        }
+        ids = std::vector<Bytes>(idHashes.begin(), idHashes.end());
+
+        for (size_t i = 0; i < m; i++) {
+            std::vector<uint8_t> buf = getRandomSeed();
+
+            PrivateKey sk = PrivateKey::FromByteVector(buf, true);
+            sks.push_back(sk);
+            pks.push_back(sk.GetG1Element());
+            sigs.push_back(bls::Threshold::Sign(sk, Bytes(vecHash)));
+            ASSERT(bls::Threshold::Verify(sk.GetG1Element(), Bytes(vecHash), sigs.back()));
+        }
+
+        G2Element sig = bls::Threshold::Sign(sks[0], Bytes(vecHash));
+
+        REQUIRE(bls::Threshold::Verify({pks[0]}, Bytes{vecHash}, {sig}));
+
+        for (size_t i = 0; i < n; i++) {
+            PrivateKey skShare = bls::Threshold::PrivateKeyShare(sks, ids[i]);
+            G1Element pkShare = bls::Threshold::PublicKeyShare(pks, ids[i]);
+            G2Element sigShare1 = bls::Threshold::SignatureShare(sigs, ids[i]);
+            REQUIRE(skShare.GetG1Element() == pkShare);
+
+            G2Element sigShare2 = bls::Threshold::Sign(skShare, Bytes(vecHash));
+            REQUIRE(sigShare1 == sigShare2);
+            REQUIRE(bls::Threshold::Verify({pkShare}, Bytes(vecHash), {sigShare1}));
+
+            skShares.push_back(skShare);
+            pkShares.push_back(pkShare);
+            sigShares.push_back(sigShare1);
+        }
+
+        std::vector<PrivateKey> rsks;
+        std::vector<G1Element> rpks;
+        std::vector<G2Element> rsigs;
+        std::vector<Bytes> rids;
+        for (size_t i = 0; i < 2; i++) {
+            rsks.push_back(skShares[i]);
+            rpks.push_back(pkShares[i]);
+            rsigs.push_back(sigShares[i]);
+            rids.push_back(ids[i]);
+        }
+        PrivateKey recSk = bls::Threshold::PrivateKeyRecover(rsks, rids);
+        G1Element recPk = bls::Threshold::PublicKeyRecover(rpks, rids);
+        G2Element recSig = bls::Threshold::SignatureRecover(rsigs, rids);
+        REQUIRE(recSk != sks[0]);
+        REQUIRE(recPk != pks[0]);
+        REQUIRE(recSig != sig);
+
+        rsks.push_back(skShares[2]);
+        rpks.push_back(pkShares[2]);
+        rsigs.push_back(sigShares[2]);
+        rids.push_back(ids[2]);
+        recSk = bls::Threshold::PrivateKeyRecover(rsks, rids);
+        recPk = bls::Threshold::PublicKeyRecover(rpks, rids);
+        recSig = bls::Threshold::SignatureRecover(rsigs, rids);
+        REQUIRE(recSk == sks[0]);
+        REQUIRE(recPk == pks[0]);
+        REQUIRE(recSig == sig);
+    }
 }
 
 int main(int argc, char* argv[])

--- a/src/threshold.cpp
+++ b/src/threshold.cpp
@@ -1,0 +1,297 @@
+// Copyright (c) 2021 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "threshold.hpp"
+
+#include "schemes.hpp"
+
+static std::unique_ptr<bls::CoreMPL> pThresholdScheme(new bls::LegacySchemeMPL);
+
+/**
+ * Inverts a prime field element using the Euclidean Extended Algorithm,
+ * using bns and a custom prime modulus.
+ *
+ * @param[out] c			- the result.
+ * @param[in] a				- the prime field element to invert.
+ * @param[in] p				- the custom prime modulus.
+ */
+static void fp_inv_exgcd_bn(bn_t c, const bn_t u_in, const bn_t p) {
+    bn_t u, v, g1, g2, q, r;
+
+    bn_null(u);
+    bn_null(v);
+    bn_null(g1);
+    bn_null(g2);
+    bn_null(q);
+    bn_null(r);
+
+    RLC_TRY {
+        bn_new(u);
+        bn_new(v);
+        bn_new(g1);
+        bn_new(g2);
+        bn_new(q);
+        bn_new(r);
+
+        /* u = a, v = p, g1 = 1, g2 = 0. */
+        bn_copy(u, u_in);
+        bn_copy(v, p);
+        bn_set_dig(g1, 1);
+        bn_zero(g2);
+
+        /* While (u != 1. */
+        while (bn_cmp_dig(u, 1) != RLC_EQ) {
+            /* q = [v/u], r = v mod u. */
+            bn_div_rem(q, r, v, u);
+            /* v = u, u = r. */
+            bn_copy(v, u);
+            bn_copy(u, r);
+            /* r = g2 - q * g1. */
+            bn_mul(r, q, g1);
+            bn_sub(r, g2, r);
+            /* g2 = g1, g1 = r. */
+            bn_copy(g2, g1);
+            bn_copy(g1, r);
+        }
+
+        if (bn_sign(g1) == RLC_NEG) {
+            bn_add(g1, g1, p);
+        }
+        bn_copy(c, g1);
+    }
+    RLC_CATCH_ANY {
+        RLC_THROW(ERR_CAUGHT);
+    }
+    RLC_FINALLY {
+        bn_free(u);
+        bn_free(v);
+        bn_free(g1);
+        bn_free(g2);
+        bn_free(q);
+        bn_free(r);
+    };
+}
+
+namespace bls {
+
+    namespace Poly {
+
+        static const int nIdSize{32};
+
+        template <typename BLSType>
+        BLSType Evaluate(const std::vector<BLSType>& vecIn, const Bytes& id);
+
+        template <typename BLSType>
+        BLSType LagrangeInterpolate(const std::vector<BLSType>& vec, const std::vector<Bytes>& ids);
+    } // end namespace Poly
+
+    struct PolyOpsBase {
+        bn_t order;
+
+        PolyOpsBase() {
+            bn_new(order);
+            gt_get_ord(order);
+        }
+
+        void MulFP(bn_t& r, const bn_t& a, const bn_t& b) {
+            bn_mul(r, a, b);
+            ModOrder(r);
+        }
+
+        void AddFP(bn_t& r, const bn_t& a, const bn_t& b) {
+            bn_add(r, a, b);
+            ModOrder(r);
+        }
+
+        void SubFP(bn_t& r, const bn_t& a, const bn_t& b) {
+            bn_sub(r, a, b);
+            ModOrder(r);
+        }
+
+        void DivFP(bn_t& r, const bn_t& a, const bn_t& b) {
+            bn_t iv;
+            bn_new(iv);
+            fp_inv_exgcd_bn(iv, b, order);
+            bn_mul(r, a, iv);
+            ModOrder(r);
+        }
+
+        void ModOrder(bn_t& r) {
+            bn_mod(r, r, order);
+        }
+    };
+
+    template<typename G>
+    struct PolyOps;
+
+    template<>
+    struct PolyOps<PrivateKey> : PolyOpsBase {
+        PrivateKey Add(const PrivateKey& a, const PrivateKey& b) {
+            return PrivateKey::Aggregate({a, b});
+        }
+
+        PrivateKey Mul(const PrivateKey& a, const bn_t& b) {
+            return a * b;
+        }
+    };
+
+    template<>
+    struct PolyOps<G1Element> : PolyOpsBase {
+        G1Element Add(const G1Element& a, const G1Element& b) {
+            return pThresholdScheme->Aggregate({a, b});
+        }
+
+        G1Element Mul(const G1Element& a, const bn_t& b) {
+            return a * b;
+        }
+    };
+
+    template<>
+    struct PolyOps<G2Element> : PolyOpsBase {
+        G2Element Add(const G2Element& a, const G2Element& b) {
+            return pThresholdScheme->Aggregate({a, b});
+        }
+
+        G2Element Mul(const G2Element& a, bn_t& b) {
+            return a * b;
+        }
+    };
+
+    template<typename BLSType>
+    BLSType Poly::Evaluate(const std::vector<BLSType>& vecIn, const Bytes& id) {
+        typedef PolyOps<BLSType> Ops;
+        Ops ops;
+        std::vector<BLSType> vec = vecIn;
+        if (vec.size() < 2) {
+            throw std::length_error("At least 2 coefficients required");
+        }
+
+        bn_t x;
+        bn_new(x);
+        bn_read_bin(x, id.begin(), Poly::nIdSize);
+        ops.ModOrder(x);
+
+        BLSType y = vecIn[vec.size() - 1];
+
+        for (int i = (int) vec.size() - 2; i >= 0; i--) {
+            y = ops.Mul(y, x);
+            y = ops.Add(y, vecIn[i]);
+        }
+
+        bn_free(x);
+
+        return y;
+    }
+
+    template<typename BLSType>
+    BLSType Poly::LagrangeInterpolate(const std::vector<BLSType>& vec, const std::vector<Bytes>& ids) {
+        typedef PolyOps<BLSType> Ops;
+        Ops ops;
+
+        if (vec.size() < 2) {
+            throw std::length_error("At least 2 shares required");
+        }
+        if (vec.size() != ids.size()) {
+            throw std::length_error("Numbers of shares and ids must be equal");
+        }
+
+        /*
+            delta_{i,S}(0) = prod_{j != i} S[j] / (S[j] - S[i]) = a / b
+            where a = prod S[j], b = S[i] * prod_{j != i} (S[j] - S[i])
+        */
+        const size_t k = vec.size();
+
+        bn_t *delta = new bn_t[k];
+        bn_t *ids2 = new bn_t[k];
+
+        for (size_t i = 0; i < k; i++) {
+            bn_new(delta[i]);
+            bn_new(ids2[i]);
+            bn_read_bin(ids2[i], ids[i].begin(), Poly::nIdSize);
+            ops.ModOrder(ids2[i]);
+        }
+
+        bn_t a, b, v;
+        bn_new(a);
+        bn_new(b);
+        bn_new(v);
+
+        auto cleanup = [&](){
+            bn_free(a);
+            bn_free(b);
+            bn_free(v);
+            for (size_t i = 0; i < k; i++) {
+                bn_free(delta[i]);
+                bn_free(ids2[i]);
+            }
+        };
+
+        bn_copy(a, ids2[0]);
+        for (size_t i = 1; i < k; i++) {
+            ops.MulFP(a, a, ids2[i]);
+        }
+        if (bn_is_zero(a)) {
+            cleanup();
+            throw std::invalid_argument("Zero id");
+        }
+        for (size_t i = 0; i < k; i++) {
+            bn_copy(b, ids2[i]);
+            for (size_t j = 0; j < k; j++) {
+                if (j != i) {
+                    ops.SubFP(v, ids2[j], ids2[i]);
+                    if (bn_is_zero(v)) {
+                        cleanup();
+                        throw std::invalid_argument("Duplicate id");
+                    }
+                    ops.MulFP(b, b, v);
+                }
+            }
+            ops.DivFP(delta[i], a, b);
+        }
+
+        /*
+            f(0) = sum_i f(S[i]) delta_{i,S}(0)
+        */
+        BLSType r;
+        for (size_t i = 0; i < k; i++) {
+            r = ops.Add(r, ops.Mul(vec[i], delta[i]));
+        }
+
+        cleanup();
+
+        return r;
+    }
+
+    PrivateKey Threshold::PrivateKeyShare(const std::vector<PrivateKey>& sks, const Bytes& id) {
+        return Poly::Evaluate(sks, id);
+    }
+
+    PrivateKey Threshold::PrivateKeyRecover(const std::vector<PrivateKey>& sks, const std::vector<Bytes>& ids) {
+        return Poly::LagrangeInterpolate(sks, ids);
+    }
+
+    G1Element Threshold::PublicKeyShare(const std::vector<G1Element>& pks, const Bytes& id) {
+        return Poly::Evaluate(pks, id);
+    }
+
+    G1Element Threshold::PublicKeyRecover(const std::vector<G1Element>& sks, const std::vector<Bytes>& ids) {
+        return Poly::LagrangeInterpolate(sks, ids);
+    }
+
+    G2Element Threshold::SignatureShare(const std::vector<G2Element>& sigs, const Bytes& id) {
+        return Poly::Evaluate(sigs, id);
+    }
+
+    G2Element Threshold::SignatureRecover(const std::vector<G2Element>& sigs, const std::vector<Bytes>& ids) {
+        return Poly::LagrangeInterpolate(sigs, ids);
+    }
+    
+    G2Element Threshold::Sign(const PrivateKey& privateKey, const Bytes& vecMessage) {
+        return pThresholdScheme->Sign(privateKey, vecMessage);
+    }
+
+    bool Threshold::Verify(const G1Element& pubKey, const Bytes& vecMessage, const G2Element& signature) {
+        return pThresholdScheme->Verify(pubKey, vecMessage, signature);
+    }
+}

--- a/src/threshold.hpp
+++ b/src/threshold.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef SRC_THRESHOLD_HPP_
+#define SRC_THRESHOLD_HPP_
+
+#include "privatekey.hpp"
+#include "elements.hpp"
+
+namespace bls {
+
+    namespace Threshold {
+
+        PrivateKey PrivateKeyShare(const std::vector<PrivateKey>& sks, const Bytes& id);
+        PrivateKey PrivateKeyRecover(const std::vector<PrivateKey>& sks, const std::vector<Bytes>& ids);
+
+        G1Element PublicKeyShare(const std::vector<G1Element>& pks, const Bytes& id);
+        G1Element PublicKeyRecover(const std::vector<G1Element>& sks, const std::vector<Bytes>& ids);
+
+        G2Element SignatureShare(const std::vector<G2Element>& sks, const Bytes& id);
+        G2Element SignatureRecover(const std::vector<G2Element>& sigs, const std::vector<Bytes>& ids);
+
+        G2Element Sign(const PrivateKey& privateKey, const Bytes& vecMessage);
+        bool Verify(const G1Element& pubKey, const Bytes& vecMessage, const G2Element& signature);
+    } // end namespace Threshold
+} // end namespace bls
+
+#endif  // SRC_THRESHOLD_HPP_


### PR DESCRIPTION
Some notes:
- The new library version has a whole new structure. What we had before in `publickey.hpp/.cpp` and `signatures.hpp/.cpp` files is now in `element.hpp/.cpp` where `G1Element` represents a public key and `G2Element` represents a signature in the (yet) only available `MPL` (Minimum pubkey length) schemes which can be found in `schemes.hpp/.cpp` (Thats the file were the signing/verification schemes defined in the standard draft are implemented by using the available primitives).
- `LegacySchemeMPL` in `schemes.hpp/.cpp` is the scheme i added to represents the signing/verification from our latest release https://github.com/dashpay/bls-signatures/releases/tag/v20181101 to make it compatible with previous dash core versions.
- I integrated all changes required for threshold fun from our latest release into the new files `threshold.hpp/.cpp` but its not 1:1, i adjusted/refactored/simplified things a bit here and there.
-  `legacy.cpp` contains some functions pulled out from the relic version which was used in the our latest release. Those are also mostly simplified or adjusted to fit our needs + in the file `threshold.cpp` we have `fp_inv_exgcd_bn` which is also pulled out from the earlier relic version.
- All the `AggregationInfo` and “secure” stuff is gone now. I pulled out only the really required parts as replacement of what we had with `bls::Signature` <> `bls::InsecureSignature` and the “secure aggregation/verification” in d50109e.