### PR TITLE
feat: added back in private keys from BIP32 Seed

### DIFF
--- a/src/privatekey.hpp
+++ b/src/privatekey.hpp
@@ -31,6 +31,9 @@ class PrivateKey {
     // less than the group order (which is in bls.hpp).
     static const size_t PRIVATE_KEY_SIZE = 32;
 
+    // Construct a private key from a BIP32 based seed.
+    static PrivateKey FromSeedBIP32(const Bytes& seed);
+
     // Construct a private key from a bytearray.
     static PrivateKey FromBytes(const Bytes& bytes, bool modOrder = false);
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -121,6 +121,13 @@ TEST_CASE("class PrivateKey") {
         REQUIRE_THROWS(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE), false));
         REQUIRE_NOTHROW(PrivateKey::FromBytes(Bytes(buffer, PrivateKey::PRIVATE_KEY_SIZE), true));
     }
+    SECTION("BIP32 Seed") {
+        uint8_t aliceSeed[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        PrivateKey pk1 = PrivateKey::FromSeedBIP32(Bytes(aliceSeed, 10));
+        vector<uint8_t> privateKey = pk1.Serialize(true);
+        vector<uint8_t> knownPrivateKey = Util::HexToBytes("46891c2cec49593c81921e473db7480029e0fc1eb933c6b93d81f5370eb19fbd");
+        REQUIRE(privateKey == knownPrivateKey);
+    }
     SECTION("keydata checks") {
         PrivateKey pk1 = PrivateKey::FromByteVector(getRandomSeed(), true);
         G1Element g1 = pk1.GetG1Element();


### PR DESCRIPTION
On iOS many of our unit tests were using this function, when it was removed in the update it made a lot of tests fail. It's far easier to add it here then rewrite the tests a different way.