### PR TITLE
Fix missing include for std::unique_ptr

### DIFF
--- a/src/threshold.cpp
+++ b/src/threshold.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <memory>
+
 #include "threshold.hpp"
 
 #include "schemes.hpp"


### PR DESCRIPTION
This template is defined in `<memory>`, but it was not included.

Somehow this was not causing problems with older versions of GCC, probably because it was transitively included by something else.

However, this caused an error with GCC 12 that is stricter in this regard.