### PR TITLE
refactor: use runtime.KeepAlive to prevent GC memory release

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,8 +31,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install valgrind -y
-        sudo apt-get install snap -y
+        sudo apt-get install -qq --yes valgrind snap libgmp-dev libsodium-dev
         sudo apt-get remove --purge cmake -y
         sudo snap install cmake --classic
         hash -r

--- a/go-bindings/Makefile
+++ b/go-bindings/Makefile
@@ -15,12 +15,12 @@ default: prepare vet test clean
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CURR_DIR := $(dir $(MAKEFILE_PATH))
 
-CGO_LDFLAGS="-L$(CURR_DIR)../build/_deps/sodium-build \
+CGO_LDFLAGS ?= "-L$(CURR_DIR)../build/_deps/sodium-build \
 -L$(CURR_DIR)../build/_deps/relic-build/lib \
 -L$(CURR_DIR)../build/src \
 -lbls-dash -lrelic_s -lgmp"
 
-CGO_CXXFLAGS="-I$(CURR_DIR)../build/_deps/relic-src/include \
+CGO_CXXFLAGS ?= "-I$(CURR_DIR)../build/_deps/relic-src/include \
 -I$(CURR_DIR)../build/_deps/relic-build/include \
 -I$(CURR_DIR)../src"
 

--- a/go-bindings/Makefile
+++ b/go-bindings/Makefile
@@ -12,15 +12,17 @@ COVERAGE_OUTPUT ?= coverage.out
 
 default: prepare vet test clean
 
-prepare:
-ifeq ("$(wildcard $(CACHE_DIR))", "")
-	@mkdir -p $(CACHE_DIR)/bls-dash
-	@mkdir -p $(CACHE_DIR)/lib
-	@find $(BUILD_DIR) -name "*.a" -exec cp {} $(CACHE_DIR)/lib \;
-	@cp -r $(BUILD_DIR)/_deps/relic-src/include/* $(CACHE_DIR)
-	@cp -r $(BUILD_DIR)/_deps/relic-build/include/* $(CACHE_DIR)
-	@cp -r $(SRC_DIR)/* $(CACHE_DIR)/bls-dash
-endif
+MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURR_DIR := $(dir $(MAKEFILE_PATH))
+
+CGO_LDFLAGS="-L$(CURR_DIR)../build/_deps/sodium-build \
+-L$(CURR_DIR)../build/_deps/relic-build/lib \
+-L$(CURR_DIR)../build/src \
+-lbls-dash -lrelic_s -lgmp"
+
+CGO_CXXFLAGS="-I$(CURR_DIR)../build/_deps/relic-src/include \
+-I$(CURR_DIR)../build/_deps/relic-build/include \
+-I$(CURR_DIR)../src"
 
 fmt:  ## Run go fmt to format Go files
 	$(GO) fmt

--- a/go-bindings/Makefile
+++ b/go-bindings/Makefile
@@ -6,10 +6,12 @@ COVERAGE_OUTPUT ?= coverage.out
 
 .PHONY: default vet test clean
 
-default: vet test clean
+default: prepare vet test clean
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CURR_DIR := $(dir $(MAKEFILE_PATH))
+
+CGO_ENABLED := 1
 
 CGO_LDFLAGS ?= "-L$(CURR_DIR)../build/_deps/sodium-build \
 -L$(CURR_DIR)../build/_deps/relic-build/lib \
@@ -18,7 +20,11 @@ CGO_LDFLAGS ?= "-L$(CURR_DIR)../build/_deps/sodium-build \
 
 CGO_CXXFLAGS ?= "-I$(CURR_DIR)../build/_deps/relic-src/include \
 -I$(CURR_DIR)../build/_deps/relic-build/include \
--I$(CURR_DIR)../src"
+-I$(CURR_DIR)../build/src"
+
+prepare:
+	@mkdir -p ../build/src/bls-dash
+	cp -rv ../src/* ../build/src/bls-dash
 
 fmt:  ## Run go fmt to format Go files
 	$(GO) fmt
@@ -41,4 +47,3 @@ help: ## Show This Help
 clean: ## Clean up transient (generated) files
 	$(GO) clean
 	rm -f $(COVERAGE_OUTPUT)
-	rm -rf $(CACHE_DIR)

--- a/go-bindings/Makefile
+++ b/go-bindings/Makefile
@@ -1,16 +1,12 @@
 SRC_DIR=$(PWD)/../src
 BUILD_DIR=$(PWD)/../build
-CACHE_DIR=$(PWD)/cache
-
-CGO_LDFLAGS="-L$(CACHE_DIR)/lib -lbls-dash -lrelic_s -lgmp"
-CGO_CXXFLAGS="-I$(CACHE_DIR)"
 
 GO="go"
 COVERAGE_OUTPUT ?= coverage.out
 
 .PHONY: default vet test clean
 
-default: prepare vet test clean
+default: vet test clean
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CURR_DIR := $(dir $(MAKEFILE_PATH))

--- a/go-bindings/elements.go
+++ b/go-bindings/elements.go
@@ -56,19 +56,26 @@ func (g *G1Element) Mul(sk *PrivateKey) *G1Element {
 		val: C.CG1ElementMul(g.val, sk.val),
 	}
 	runtime.SetFinalizer(&el, func(el *G1Element) { el.free() })
+	runtime.KeepAlive(g)
+	runtime.KeepAlive(sk)
 	return &el
 }
 
 // EqualTo returns true if the elements are equal otherwise returns false
 // this method is the binding of the equality operation
 func (g *G1Element) EqualTo(el *G1Element) bool {
-	return bool(C.CG1ElementIsEqual(g.val, el.val))
+	val := bool(C.CG1ElementIsEqual(g.val, el.val))
+	runtime.KeepAlive(g)
+	runtime.KeepAlive(el)
+	return val
 }
 
 // IsValid returns true if a state of G1Element (public key) is valid
 // this method is the binding of the bls::G1Element::IsValid
 func (g *G1Element) IsValid() bool {
-	return bool(C.CG1ElementIsValid(g.val))
+	isValid := bool(C.CG1ElementIsValid(g.val))
+	runtime.KeepAlive(g)
+	return isValid
 }
 
 // Add performs addition operation on the passed G1Element (public key) and returns a new G1Element (public key)
@@ -78,13 +85,17 @@ func (g *G1Element) Add(el *G1Element) *G1Element {
 		val: C.CG1ElementAdd(g.val, el.val),
 	}
 	runtime.SetFinalizer(&res, func(res *G1Element) { res.free() })
+	runtime.KeepAlive(g)
+	runtime.KeepAlive(el)
 	return &res
 }
 
 // Fingerprint returns a fingerprint of G1Element (public key)
 // this method is a binding of the bls::G1Element::GetFingerprint
 func (g *G1Element) Fingerprint() int {
-	return int(C.CG1ElementGetFingerprint(g.val))
+	fp := int(C.CG1ElementGetFingerprint(g.val))
+	runtime.KeepAlive(g)
+	return fp
 }
 
 // Serialize serializes G1Element (public key) into a slice of bytes and returns it
@@ -92,7 +103,9 @@ func (g *G1Element) Fingerprint() int {
 func (g *G1Element) Serialize() []byte {
 	ptr := C.CG1ElementSerialize(g.val)
 	defer C.free(unsafe.Pointer(ptr))
-	return C.GoBytes(ptr, C.CG1ElementSize())
+	bytes := C.GoBytes(ptr, C.CG1ElementSize())
+	runtime.KeepAlive(g)
+	return bytes
 }
 
 // HexString returns a hex string representation of serialized data
@@ -131,6 +144,7 @@ func G2ElementFromBytes(data []byte) (*G2Element, error) {
 // this method is the binding of the equality operation
 func (g *G2Element) EqualTo(el *G2Element) bool {
 	isEqual := bool(C.CG2ElementIsEqual(g.val, el.val))
+	runtime.KeepAlive(g)
 	return isEqual
 }
 
@@ -141,6 +155,8 @@ func (g *G2Element) Add(el *G2Element) *G2Element {
 		val: C.CG2ElementAdd(g.val, el.val),
 	}
 	runtime.SetFinalizer(&res, func(res *G2Element) { res.free() })
+	runtime.KeepAlive(g)
+	runtime.KeepAlive(el)
 	return &res
 }
 
@@ -151,6 +167,8 @@ func (g *G2Element) Mul(sk *PrivateKey) *G2Element {
 		val: C.CG2ElementMul(g.val, sk.val),
 	}
 	runtime.SetFinalizer(&el, func(el *G2Element) { el.free() })
+	runtime.KeepAlive(g)
+	runtime.KeepAlive(sk)
 	return &el
 }
 
@@ -159,7 +177,9 @@ func (g *G2Element) Mul(sk *PrivateKey) *G2Element {
 func (g *G2Element) Serialize() []byte {
 	ptr := C.CG2ElementSerialize(g.val)
 	defer C.free(unsafe.Pointer(ptr))
-	return C.GoBytes(ptr, C.CG2ElementSize())
+	bytes := C.GoBytes(ptr, C.CG2ElementSize())
+	runtime.KeepAlive(g)
+	return bytes
 }
 
 // HexString returns a hex string representation of serialized data

--- a/go-bindings/elements.go
+++ b/go-bindings/elements.go
@@ -14,7 +14,7 @@
 
 package blschia
 
-// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium
+// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium -lgmp
 // #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>

--- a/go-bindings/privatekey.go
+++ b/go-bindings/privatekey.go
@@ -58,6 +58,7 @@ func (sk *PrivateKey) G1Element() (*G1Element, error) {
 		return nil, errFromC()
 	}
 	runtime.SetFinalizer(&el, func(el *G1Element) { el.free() })
+	runtime.KeepAlive(sk)
 	return &el, nil
 }
 
@@ -72,6 +73,7 @@ func (sk *PrivateKey) G2Element() (*G2Element, error) {
 	if bool(cDidErr) {
 		return nil, errFromC()
 	}
+	runtime.KeepAlive(sk)
 	return &el, nil
 }
 
@@ -82,6 +84,8 @@ func (sk *PrivateKey) G2Power(el *G2Element) *G2Element {
 		val: C.CPrivateKeyGetG2Power(sk.val, el.val),
 	}
 	runtime.SetFinalizer(&sig, func() { sig.free() })
+	runtime.KeepAlive(sk)
+	runtime.KeepAlive(el)
 	return &sig
 }
 
@@ -90,7 +94,9 @@ func (sk *PrivateKey) G2Power(el *G2Element) *G2Element {
 func (sk *PrivateKey) Serialize() []byte {
 	ptr := C.CPrivateKeySerialize(sk.val)
 	defer C.SecFree(ptr)
-	return C.GoBytes(ptr, C.int(C.CPrivateKeySizeBytes()))
+	bytes := C.GoBytes(ptr, C.int(C.CPrivateKeySizeBytes()))
+	runtime.KeepAlive(sk)
+	return bytes
 }
 
 // PrivateKeyAggregate securely aggregates multiple private keys into one
@@ -102,13 +108,17 @@ func PrivateKeyAggregate(sks ...*PrivateKey) *PrivateKey {
 		val: C.CPrivateKeyAggregate(cPrivKeyArrPtr, C.size_t(len(sks))),
 	}
 	runtime.SetFinalizer(&sk, func(p *PrivateKey) { p.free() })
+	runtime.KeepAlive(sks)
 	return &sk
 }
 
 // EqualTo tests if one PrivateKey is equal to another
 // this method is the binding of the equality operation
 func (sk *PrivateKey) EqualTo(other *PrivateKey) bool {
-	return bool(C.CPrivateKeyIsEqual(sk.val, other.val))
+	isEqual := bool(C.CPrivateKeyIsEqual(sk.val, other.val))
+	runtime.KeepAlive(sk)
+	runtime.KeepAlive(other)
+	return isEqual
 }
 
 // HexString returns a hex string representation of serialized data

--- a/go-bindings/privatekey.go
+++ b/go-bindings/privatekey.go
@@ -14,7 +14,7 @@
 
 package blschia
 
-// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium
+// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium -lgmp
 // #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>

--- a/go-bindings/schemes.go
+++ b/go-bindings/schemes.go
@@ -85,15 +85,19 @@ func (s *coreMPL) KeyGen(seed []byte) (*PrivateKey, error) {
 		return nil, errFromC()
 	}
 	runtime.SetFinalizer(&sk, func(sk *PrivateKey) { sk.free() })
+	runtime.KeepAlive(s)
 	return &sk, nil
 }
 
 // SkToG1 converts PrivateKey into G1Element (public key)
 // this method is a binding of bls::CoreMPL::SkToG1
 func (s *coreMPL) SkToG1(sk *PrivateKey) *G1Element {
-	return &G1Element{
+	el := &G1Element{
 		val: C.CCoreMPSkToG1(s.val, sk.val),
 	}
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(sk)
+	return el
 }
 
 // Sign signs a message using a PrivateKey and returns the G2Element as a signature
@@ -105,6 +109,8 @@ func (s *coreMPL) Sign(sk *PrivateKey, msg []byte) *G2Element {
 		val: C.CCoreMPLSign(s.val, sk.val, cMsgPtr, C.size_t(len(msg))),
 	}
 	runtime.SetFinalizer(&sig, func(sig *G2Element) { sig.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(sk)
 	return &sig
 }
 
@@ -114,6 +120,9 @@ func (s *coreMPL) Verify(pk *G1Element, msg []byte, sig *G2Element) bool {
 	cMsgPtr := C.CBytes(msg)
 	defer C.free(cMsgPtr)
 	isVerified := bool(C.CCoreMPLVerify(s.val, pk.val, cMsgPtr, C.size_t(len(msg)), sig.val))
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(pk)
+	runtime.KeepAlive(sig)
 	return isVerified
 }
 
@@ -126,6 +135,8 @@ func (s *coreMPL) AggregatePubKeys(pks ...*G1Element) *G1Element {
 		val: C.CCoreMPLAggregatePubKeys(s.val, cPkArrPtr, C.size_t(len(pks))),
 	}
 	runtime.SetFinalizer(&aggSig, func(aggSig *G1Element) { aggSig.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(pks)
 	return &aggSig
 }
 
@@ -139,6 +150,8 @@ func (s *coreMPL) AggregateSigs(sigs ...*G2Element) *G2Element {
 		val: C.CCoreMPLAggregateSigs(s.val, cSigArrPtr, C.size_t(len(sigs))),
 	}
 	runtime.SetFinalizer(&aggSig, func(aggSig *G2Element) { aggSig.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(sigs)
 	return &aggSig
 }
 
@@ -149,6 +162,8 @@ func (s *coreMPL) DeriveChildSk(sk *PrivateKey, index int) *PrivateKey {
 		val: C.CCoreMPLDeriveChildSk(s.val, sk.val, C.uint32_t(index)),
 	}
 	runtime.SetFinalizer(&res, func(res *PrivateKey) { res.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(sk)
 	return &res
 }
 
@@ -159,6 +174,8 @@ func (s *coreMPL) DeriveChildSkUnhardened(sk *PrivateKey, index int) *PrivateKey
 		val: C.CCoreMPLDeriveChildSkUnhardened(s.val, sk.val, C.uint32_t(index)),
 	}
 	runtime.SetFinalizer(&res, func(res *PrivateKey) { res.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(sk)
 	return &res
 }
 
@@ -169,6 +186,8 @@ func (s *coreMPL) DeriveChildPkUnhardened(el *G1Element, index int) *G1Element {
 		val: C.CCoreMPLDeriveChildPkUnhardened(s.val, el.val, C.uint32_t(index)),
 	}
 	runtime.SetFinalizer(&res, func(res *G1Element) { res.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(el)
 	return &res
 }
 
@@ -189,6 +208,9 @@ func (s *coreMPL) AggregateVerify(pks []*G1Element, msgs [][]byte, sig *G2Elemen
 		C.size_t(len(msgs)),
 		sig.val,
 	)
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(pks)
+	runtime.KeepAlive(sig)
 	return bool(val)
 }
 
@@ -225,6 +247,9 @@ func (s *BasicSchemeMPL) AggregateVerify(pks []*G1Element, msgs [][]byte, sig *G
 		C.size_t(len(msgs)),
 		sig.val,
 	)
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(pks)
+	runtime.KeepAlive(sig)
 	return bool(val)
 }
 
@@ -260,6 +285,8 @@ func (s *AugSchemeMPL) Sign(sk *PrivateKey, msg []byte) *G2Element {
 		val: C.CAugSchemeMPLSign(s.val, sk.val, cMsgPtr, C.size_t(len(msg))),
 	}
 	runtime.SetFinalizer(&sig, func(sig *G2Element) { sig.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(sk)
 	return &sig
 }
 
@@ -270,6 +297,9 @@ func (s *AugSchemeMPL) SignPrepend(sk *PrivateKey, msg []byte, prepPk *G1Element
 		val: C.CAugSchemeMPLSignPrepend(s.val, sk.val, C.CBytes(msg), C.size_t(len(msg)), prepPk.val),
 	}
 	runtime.SetFinalizer(&sig, func(sig *G2Element) { sig.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(sk)
+	runtime.KeepAlive(prepPk)
 	return &sig
 }
 
@@ -279,6 +309,9 @@ func (s *AugSchemeMPL) Verify(pk *G1Element, msg []byte, sig *G2Element) bool {
 	cMsgPtr := C.CBytes(msg)
 	defer C.free(cMsgPtr)
 	val := C.CAugSchemeMPLVerify(s.val, pk.val, cMsgPtr, C.size_t(len(msg)), sig.val)
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(pk)
+	runtime.KeepAlive(sig)
 	return bool(val)
 }
 
@@ -298,6 +331,9 @@ func (s *AugSchemeMPL) AggregateVerify(pks []*G1Element, msgs [][]byte, sig *G2E
 		C.size_t(len(msgs)),
 		sig.val,
 	)
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(pks)
+	runtime.KeepAlive(sig)
 	return bool(val)
 }
 
@@ -331,13 +367,19 @@ func (s *PopSchemeMPL) PopProve(sk *PrivateKey) *G2Element {
 		val: C.CPopSchemeMPLPopProve(s.val, sk.val),
 	}
 	runtime.SetFinalizer(&sig, func(sig *G2Element) { sig.free() })
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(sk)
 	return &sig
 }
 
 // PopVerify verifies of a signature using proof of possession
 // this method is a binding of bls::PopSchemeMPL::PopVerify
 func (s *PopSchemeMPL) PopVerify(pk *G1Element, sig *G2Element) bool {
-	return bool(C.CPopSchemeMPLPopVerify(s.val, pk.val, sig.val))
+	isVerified := bool(C.CPopSchemeMPLPopVerify(s.val, pk.val, sig.val))
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(pk)
+	runtime.KeepAlive(sig)
+	return isVerified
 }
 
 // FastAggregateVerify uses for a fast verification
@@ -354,6 +396,9 @@ func (s *PopSchemeMPL) FastAggregateVerify(pks []*G1Element, msg []byte, sig *G2
 		C.size_t(len(msg)),
 		sig.val,
 	)
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(pks)
+	runtime.KeepAlive(sig)
 	return bool(isVerified)
 }
 

--- a/go-bindings/schemes.go
+++ b/go-bindings/schemes.go
@@ -14,7 +14,7 @@
 
 package blschia
 
-// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium
+// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium -lgmp
 // #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>

--- a/go-bindings/threshold.go
+++ b/go-bindings/threshold.go
@@ -78,6 +78,7 @@ func ThresholdPrivateKeyShare(sks []*PrivateKey, hash Hash) (*PrivateKey, error)
 		return nil, errFromC()
 	}
 	runtime.SetFinalizer(&sk, func(pk *PrivateKey) { sk.free() })
+	runtime.KeepAlive(sks)
 	return &sk, nil
 }
 
@@ -97,6 +98,7 @@ func ThresholdPublicKeyShare(pks []*G1Element, hash Hash) (*G1Element, error) {
 		return nil, errFromC()
 	}
 	runtime.SetFinalizer(&pk, func(pk *G1Element) { pk.free() })
+	runtime.KeepAlive(pks)
 	return &pk, nil
 }
 
@@ -116,6 +118,7 @@ func ThresholdSignatureShare(sigs []*G2Element, hash Hash) (*G2Element, error) {
 		return nil, errFromC()
 	}
 	runtime.SetFinalizer(&sig, func(pk *G2Element) { sig.free() })
+	runtime.KeepAlive(sigs)
 	return &sig, nil
 }
 
@@ -141,6 +144,7 @@ func ThresholdPrivateKeyRecover(sks []*PrivateKey, hashes []Hash) (*PrivateKey, 
 		return nil, errFromC()
 	}
 	runtime.SetFinalizer(&sk, func(sk *PrivateKey) { sk.free() })
+	runtime.KeepAlive(sks)
 	return &sk, nil
 }
 
@@ -166,6 +170,7 @@ func ThresholdPublicKeyRecover(pks []*G1Element, hashes []Hash) (*G1Element, err
 		return nil, errFromC()
 	}
 	runtime.SetFinalizer(&pk, func(pk *G1Element) { pk.free() })
+	runtime.KeepAlive(pks)
 	return &pk, nil
 }
 
@@ -191,6 +196,7 @@ func ThresholdSignatureRecover(sigs []*G2Element, hashes []Hash) (*G2Element, er
 		return nil, errFromC()
 	}
 	runtime.SetFinalizer(&sig, func(sig *G2Element) { sig.free() })
+	runtime.KeepAlive(sigs)
 	return &sig, nil
 }
 
@@ -203,6 +209,7 @@ func ThresholdSign(sk *PrivateKey, hash Hash) *G2Element {
 		val: C.CThresholdSign(sk.val, cHashPtr),
 	}
 	runtime.SetFinalizer(&sig, func(sig *G2Element) { sig.free() })
+	runtime.KeepAlive(sk)
 	return &sig
 }
 
@@ -212,6 +219,8 @@ func ThresholdVerify(pk *G1Element, hash Hash, sig *G2Element) bool {
 	cHashPtr := C.CBytes(hash[:])
 	defer C.free(cHashPtr)
 	val := C.CThresholdVerify(pk.val, cHashPtr, sig.val)
+	runtime.KeepAlive(pk)
+	runtime.KeepAlive(sig)
 	return bool(val)
 }
 

--- a/go-bindings/threshold.go
+++ b/go-bindings/threshold.go
@@ -14,7 +14,7 @@
 
 package blschia
 
-// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium
+// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium -lgmp
 // #cgo CXXFLAGS: -std=c++14
 // #include <stdlib.h>
 // #include "threshold.h"

--- a/go-bindings/util.go
+++ b/go-bindings/util.go
@@ -14,7 +14,7 @@
 
 package blschia
 
-// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium
+// #cgo LDFLAGS: -lbls-dash -lrelic_s -lsodium -lgmp
 // #cgo CXXFLAGS: -std=c++14
 // #include "blschia.h"
 // #include <string.h>


### PR DESCRIPTION
To prevent releasing allocated memory, we have to use `runtime.KeepAlive` function to inform GC about it
This PR adds `runtime.KeepAlive` calls, to ensure memory is consistent