### PR TITLE
fix: `Request failed \"404 Not Found\"".`

### DIFF
--- a/js_test.sh
+++ b/js_test.sh
@@ -3,6 +3,7 @@
 YARN=yarn
 if which yarn >/dev/null ; then
     YARN=yarn
+    yarn config set registry https://registry.npmjs.org
 else
     if which npm >/dev/null ; then
         YARN=npm


### PR DESCRIPTION
Recent merges broke GH actions https://github.com/dashpay/bls-signatures/actions/runs/2592128395 but it's not their fault, it's `yarn` behaving weird it seems. Applying one of suggestions from https://github.com/yarnpkg/yarn/issues/2738 fixed it for me https://github.com/UdjinM6/bls-signatures/actions/runs/2593145863