### PR TITLE
fix: build with ubuntu 22.10 (gcc 12) due to missing header

### DIFF
--- a/src/threshold.cpp
+++ b/src/threshold.cpp
@@ -6,6 +6,8 @@
 
 #include "schemes.hpp"
 
+#include <memory>
+
 static std::unique_ptr<bls::CoreMPL> pThresholdScheme(new bls::LegacySchemeMPL);
 
 /**


### PR DESCRIPTION
The header <memory> should be included explicitly.