### PR TITLE
build: disable gmp if targeting darwin on aarch64 when on 'auto'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,21 @@ AC_ARG_WITH([backend],
 if test x"$want_backend" = x"auto"; then
   GMP_CHECK
   if test x"$has_gmp" = x"yes"; then
-    want_backend=gmp
+    case $host in
+      *darwin*)
+        case $host_cpu in
+          aarch*)
+            want_backend=easy
+            ;;
+          *)
+            want_backend=gmp
+            ;;
+        esac
+        ;;
+      *)
+        want_backend=gmp
+        ;;
+    esac
   else
     want_backend=easy
   fi


### PR DESCRIPTION
## Why?
macOS Ventura causes the GMP test suite to fail, which in turn causes the library to behave erratically. Until such errata are rectified upstream by libgmp, we have automatic backend selection pick the easy backend if targeting macOS on Apple Silicon.