### PR TITLE
fix: built for glibc 2.35

### DIFF
--- a/src/test.cpp
+++ b/src/test.cpp
@@ -17,6 +17,11 @@
 #include <thread>
 
 #include "bls.hpp"
+
+// the define `MINSIGSTKSZ` can not be used in constexpr since glibc v2.35
+// this flag resolve constexpr issue for catch2 library
+// can be removed after upgrade to catch2 v2.13.5 or newer
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include <catch2/catch.hpp>
 
 extern "C" {


### PR DESCRIPTION
Macros `MINSIGSTKSZ` is not a const anymore in glibc 2.35, but a function call
    
It causes this error:
```
        error: call to non-‘constexpr’ function ‘long int sysconf(int)’
        10822 |     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
```

Alternate solution to update catch2 library to version 2.13.5 or newer: https://github.com/catchorg/Catch2/blob/devel/docs/release-notes.md#2135