### PR TITLE
fix: Reinit Relic lib while processing basic data in legacy mode.

### DIFF
--- a/include/dashbls/bls.hpp
+++ b/include/dashbls/bls.hpp
@@ -41,7 +41,7 @@ class BLS {
 
     static void SetSecureAllocator(Util::SecureAllocCallback allocCb, Util::SecureFreeCallback freeCb);
 
-    static void CheckRelicErrors();
+    static void CheckRelicErrors(bool should_throw = true);
 };
 } // end namespace bls
 

--- a/src/bls.cpp
+++ b/src/bls.cpp
@@ -78,14 +78,16 @@ void BLS::SetSecureAllocator(
 }
 
 
-void BLS::CheckRelicErrors()
+void BLS::CheckRelicErrors(bool should_throw)
 {
     if (!core_get()) {
         throw std::runtime_error("Library not initialized properly. Call BLS::Init()");
     }
     if (core_get()->code != RLC_OK) {
         core_get()->code = RLC_OK;
-        throw std::invalid_argument("Relic library error");
+        if (should_throw) {
+            throw std::invalid_argument("Relic library error");
+        }
     }
 }
 

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -82,9 +82,7 @@ G1Element G1Element::FromBytesUnchecked(Bytes const bytes, bool fLegacy)
         }
     }
     g1_read_bin(ele.p, buffer, G1Element::SIZE + 1);
-    if (!fLegacy) {
-        BLS::CheckRelicErrors();
-    }
+    BLS::CheckRelicErrors(!fLegacy);
     return ele;
 }
 
@@ -293,9 +291,7 @@ G2Element G2Element::FromBytesUnchecked(Bytes const bytes, const bool fLegacy)
     }
 
     g2_read_bin(ele.q, buffer, G2Element::SIZE + 1);
-    if (!fLegacy) {
-        BLS::CheckRelicErrors();
-    }
+    BLS::CheckRelicErrors(!fLegacy);
     return ele;
 }
 


### PR DESCRIPTION
This PR protects the library from staying in a invalid state when trying to unserialize data encoded in basic BLS scheme in legacy.
This fix basically resets Relic library and avoids throwing an exception on such case.