### PR TITLE
feat: implement memory-copy only of G1Element and G2Element

### DIFF
--- a/include/dashbls/elements.hpp
+++ b/include/dashbls/elements.hpp
@@ -59,6 +59,7 @@ public:
     GTElement Pair(const G2Element &b) const;
     uint32_t GetFingerprint(bool fLegacy = false) const;
     std::vector<uint8_t> Serialize(bool fLegacy = false) const;
+    G1Element Copy();
 
     friend bool operator==(const G1Element &a, const G1Element &b);
     friend bool operator!=(const G1Element &a, const G1Element &b);
@@ -101,6 +102,7 @@ public:
     G2Element Negate() const;
     GTElement Pair(const G1Element &a) const;
     std::vector<uint8_t> Serialize(bool fLegacy = false) const;
+    G2Element Copy();
 
     friend bool operator==(G2Element const &a, G2Element const &b);
     friend bool operator!=(G2Element const &a, G2Element const &b);

--- a/rust-bindings/bls-dash-sys/bindings.rs
+++ b/rust-bindings/bls-dash-sys/bindings.rs
@@ -33,6 +33,8 @@ extern "C" {
 
     pub fn G1ElementNegate(el: G1Element) -> G1Element;
 
+    pub fn G1ElementCopy(el: G1Element) -> G1Element;
+
     pub fn G1ElementSerialize(el: G1Element, legacy: bool) -> *mut ::std::os::raw::c_void;
 
     pub fn G1ElementFree(el: G1Element);
@@ -56,6 +58,8 @@ extern "C" {
     pub fn G2ElementMul(el: G2Element, sk: PrivateKey) -> G2Element;
 
     pub fn G2ElementNegate(el: G2Element) -> G2Element;
+
+    pub fn G2ElementCopy(el: G2Element) -> G2Element;
 
     pub fn G2ElementSerialize(el: G2Element, legacy: bool) -> *mut ::std::os::raw::c_void;
 

--- a/rust-bindings/bls-dash-sys/c-bindings/elements.cpp
+++ b/rust-bindings/bls-dash-sys/c-bindings/elements.cpp
@@ -83,6 +83,10 @@ G1Element G1ElementNegate(const G1Element el) {
     return new bls::G1Element(elPtr->Negate());
 }
 
+G1Element G1ElementCopy(const G1Element el) {
+    return new bls::G1Element(((bls::G1Element*)el)->Copy());
+}
+
 void G1ElementFree(const G1Element el) {
     const bls::G1Element* elPtr = (bls::G1Element*)el;
     delete elPtr;
@@ -146,6 +150,10 @@ G2Element G2ElementMul(const G2Element el, const PrivateKey sk) {
 G2Element G2ElementNegate(const G2Element el) {
     const bls::G2Element* elPtr = (bls::G2Element*)el;
     return new bls::G2Element(elPtr->Negate());
+}
+
+G2Element G2ElementCopy(const G1Element el) {
+    return new bls::G2Element(((bls::G2Element*)el)->Copy());
 }
 
 void G2ElementFree(const G2Element el) {

--- a/rust-bindings/bls-dash-sys/c-bindings/elements.h
+++ b/rust-bindings/bls-dash-sys/c-bindings/elements.h
@@ -35,6 +35,7 @@ bool G1ElementIsEqual(const G1Element el1, const G1Element el2);
 G1Element G1ElementAdd(const G1Element el1, const G1Element el2);
 G1Element G1ElementMul(const G1Element el, const PrivateKey sk);
 G1Element G1ElementNegate(const G1Element el);
+G1Element G1ElementCopy(const G1Element el);
 void* G1ElementSerialize(const G1Element el, const bool legacy);
 void G1ElementFree(const G1Element el);
 
@@ -47,6 +48,7 @@ bool G2ElementIsEqual(const G2Element el1, const G2Element el2);
 G2Element G2ElementAdd(const G2Element el1, const G2Element el2);
 G2Element G2ElementMul(const G2Element el, const PrivateKey sk);
 G2Element G2ElementNegate(const G2Element el);
+G2Element G2ElementCopy(const G2Element el);
 void* G2ElementSerialize(const G2Element el, const bool legacy);
 void G2ElementFree(const G2Element el);
 

--- a/rust-bindings/bls-signatures/src/elements.rs
+++ b/rust-bindings/bls-signatures/src/elements.rs
@@ -1,11 +1,6 @@
 use std::ffi::c_void;
 
-use bls_dash_sys::{
-    CoreMPLDeriveChildPkUnhardened, G1ElementFree, G1ElementFromBytes, G1ElementGenerator,
-    G1ElementGetFingerprint, G1ElementIsEqual, G1ElementSerialize, G2ElementFree,
-    G2ElementFromBytes, G2ElementIsEqual, G2ElementSerialize, ThresholdPublicKeyRecover,
-    ThresholdSignatureRecover,
-};
+use bls_dash_sys::{CoreMPLDeriveChildPkUnhardened, G1ElementFree, G1ElementFromBytes, G1ElementGenerator, G1ElementGetFingerprint, G1ElementIsEqual, G1ElementSerialize, G1ElementCopy, G2ElementCopy, G2ElementFree, G2ElementFromBytes, G2ElementIsEqual, G2ElementSerialize, ThresholdPublicKeyRecover, ThresholdSignatureRecover};
 #[cfg(feature = "use_serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -134,10 +129,9 @@ impl G1Element {
 
 impl Clone for G1Element {
     fn clone(&self) -> Self {
-        // Serialize the element
-        let bytes = self.to_bytes();
-        // We can panic
-        G1Element::from_bytes(bytes.as_slice()).expect("expected bytes to be valid")
+        unsafe {
+            G1Element{c_element: G1ElementCopy(self.c_element)}
+        }
     }
 }
 
@@ -263,10 +257,9 @@ impl G2Element {
 
 impl Clone for G2Element {
     fn clone(&self) -> Self {
-        // Serialize the element
-        let bytes = self.to_bytes();
-        // We can panic
-        G2Element::from_bytes(bytes.as_slice()).expect("expected bytes to be valid")
+        unsafe {
+            G2Element{c_element: G2ElementCopy(self.c_element)}
+        }
     }
 }
 

--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -98,6 +98,14 @@ G1Element G1Element::FromNative(const g1_t element)
     return ele;
 }
 
+G1Element G1Element::Copy() {
+    G1Element ele;
+    g1_copy(ele.p, this->p);
+
+    return ele;
+}
+
+
 G1Element G1Element::FromMessage(const std::vector<uint8_t>& message,
                                  const uint8_t* dst,
                                  int dst_len)
@@ -357,6 +365,14 @@ void G2Element::CheckValid() const {
 void G2Element::ToNative(g2_t output) const {
     g2_copy(output, (g2_st*)q);
 }
+
+G2Element G2Element::Copy() {
+    G2Element ele;
+    g2_copy(ele.q, this->q);
+
+    return ele;
+}
+
 
 G2Element G2Element::Negate() const
 {


### PR DESCRIPTION
extend it out to bindings as well