### PR TITLE
fix: dash is no more pretending being a 'libdashbls'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -783,3 +783,4 @@ AC_OUTPUT
 
 dnl Peplace conflict-prone PACKAGE-prefixed macros with DASHBLS
 sed -i.old 's/PACKAGE/DASHBLS/g' depends/relic/include/relic_conf.h
+sed -i.old 's/PACKAGE/DASHBLS/g' config.status


### PR DESCRIPTION
It resolves: https://github.com/dashpay/dash/issues/5270

It is still workaround but it should be more reliable.