### PR TITLE
build: enforce minimum versions of libgmp based on arch and platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -229,21 +229,7 @@ if test x"$want_backend" = x"auto"; then
   else
     GMP_CHECK
     if test x"$has_gmp" = x"yes"; then
-      case $host in
-        *darwin*)
-          case $host_cpu in
-            aarch*)
-              want_backend=easy
-              ;;
-            *)
-              want_backend=gmp
-              ;;
-          esac
-          ;;
-        *)
-          want_backend=gmp
-          ;;
-      esac
+      want_backend=gmp
     else
       want_backend=easy
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -148,15 +148,56 @@ AC_DEFINE([GMP],     [2], [Backend based on GNU Multiple Precision library.])
 AC_DEFINE([GMP_SEC], [3], [Backend based on GNU Multiple Precision library, but using constant-time code.])
 
 AC_DEFUN([GMP_CHECK],[
-if test x"$has_gmp" != x"yes"; then
+  AC_REQUIRE([AC_PROG_CC])
+
   CPPFLAGS_TEMP="$CPPFLAGS"
   CPPFLAGS="$GMP_CPPFLAGS $CPPFLAGS"
   LIBS_TEMP="$LIBS"
   LIBS="$GMP_LDFLAGS $LIBS"
-  AC_CHECK_HEADER(gmp.h,[AC_CHECK_LIB(gmp, __gmpz_init,[has_gmp=yes; GMP_LIBS="-lgmp";])])
+
+  AC_CHECK_HEADER(
+    gmp.h,
+    [AC_CHECK_LIB(gmp, __gmpz_init, [], [gmp_fail_reason="libgmp not found or unusable"; has_gmp=no;])],
+    [gmp_fail_reason="gmp header not found"; has_gmp=no;]
+  )
+
+  if test x"$has_gmp" != x"no"; then
+    # Proper support for macOS aarch64 was introduced in 6.3.0, but LTS distros
+    # like Ubuntu 20.04 (focal) use 6.2.0, so, the minimum supported version is
+    # determined by platform and architecture.
+    case $host in
+      *darwin*)
+        case $host_cpu in
+          aarch*)
+            gmp_major_version=6
+            gmp_minor_version=3
+            ;;
+        esac
+        ;;
+      *)
+        gmp_major_version=6
+        gmp_minor_version=2
+        ;;
+    esac
+    AC_MSG_CHECKING([gmp version >= $gmp_major_version.$gmp_minor_version])
+    AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM(
+        [[@%:@include <gmp.h>]],
+        [[
+          @%:@if __GNU_MP_VERSION < $gmp_major_version || __GNU_MP_VERSION_MINOR < $gmp_minor_version
+            @%:@error Unsupported GMP version
+          @%:@endif]])],
+      [AC_MSG_RESULT([yes]); GMP_LIBS="-lgmp"; has_gmp=yes;],
+      [AC_MSG_RESULT([no]); gmp_fail_reason="unsupported gmp version"; has_gmp=no;]
+    )
+  fi
+
+  if test x"$want_backend" = x"gmp" && test x"$has_gmp" = x"no"; then
+    AC_MSG_ERROR([$gmp_fail_reason])
+  fi
+
   CPPFLAGS="$CPPFLAGS_TEMP"
   LIBS="$LIBS_TEMP"
-fi
 ])
 
 AC_ARG_WITH([backend],
@@ -210,10 +251,8 @@ if test x"$want_backend" = x"auto"; then
 else
   case $want_backend in
   gmp)
+    dnl GMP_CHECK will report the reason if and why the backend cannot be used.
     GMP_CHECK
-    if test x"$has_gmp" != x"yes"; then
-      AC_MSG_ERROR([gmp backend explicitly requested but libgmp not available])
-    fi
     ;;
   easy)
     ;;

--- a/configure.ac
+++ b/configure.ac
@@ -35,14 +35,9 @@ else
   CXXFLAGS_overridden=no
 fi
 
+AC_PROG_CC
+
 AC_PROG_CXX
-
-AM_PROG_CC_C_O
-
-AC_PROG_CC_C99
-if test x"$ac_cv_prog_cc_c99" = x"no"; then
-  AC_MSG_ERROR([c99 compiler support required])
-fi
 
 dnl By default, libtool for mingw refuses to link static libs into a dll for
 dnl fear of mixing pic/non-pic objects, and import/export complications. Since


### PR DESCRIPTION
## Motivation

[bls-signatures#52](https://github.com/dashpay/bls-signatures/pull/52) was merged in due to a bug in libgmp ([source](https://gmplib.org/list-archives/gmp-bugs/2022-November/005217.html)) that resulted in erratic behavior certain macOS environments. This has since been resolved with GMP 6.3.0 ([source](https://gmplib.org/gmp6.3)) and is available with Homebrew ([source](https://github.com/Homebrew/homebrew-core/blob/51c899140c84d38dfa4c4fe623c859e6241504a0/Formula/g/gmp.rb#L5)).  Ubuntu 20.04 (`focal`) distributes GMP 6.2.0 ([source](https://packages.ubuntu.com/focal/libgmp-dev)) and Debian 11 (`bullseye`) distributes GMP 6.2.1 ([source](https://packages.debian.org/search?suite=bullseye&arch=any&searchon=names&keywords=libgmp-dev)) and these versions work fine with `dashbls` in their respective environments.

As the bug only affects Apple Silicon Macs running macOS Ventura and above, we need to test against a minimum version differentiated by platform and architecture. This pull request aims to do that.

## Additional Information

* Depends on https://github.com/dashpay/bls-signatures/pull/91
* The minimum version of GMP for Apple Silicon (`aarch64`) macOS hosts will be 6.3.0 **regardless of macOS version** and 6.2.0 on all other platforms.