### PR TITLE
chore: change of gmp source

### DIFF
--- a/apple.rust.deps.sh
+++ b/apple.rust.deps.sh
@@ -59,7 +59,7 @@ prepare() {
         pushd ${BUILD}
         mkdir -p "contrib"
         if [ ! -s "contrib/gmp-${GMP_VERSION}.tar.bz2" ]; then
-            curl -L -o "contrib/gmp-${GMP_VERSION}.tar.bz2" https://gmplib.org/download/gmp/gmp-${GMP_VERSION}.tar.bz2
+            curl -L -o "contrib/gmp-${GMP_VERSION}.tar.bz2" https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.bz2
         fi
         rm -rf "contrib/gmp"
         # shellcheck disable=SC2039,SC2164


### PR DESCRIPTION
CI in `dash-shared-core` repo that compiles `bls_signatures` is failing because GMP project [has banned](https://www.theregister.com/2023/06/28/microsofts_github_gmp_project/) the GitHub Actions/Azure ranges.

To bypass this, this PR changes the source of download to some other location, e.g. https://ftp.gnu.org/gnu/gmp/