### PR TITLE
refactor: bump pybind version to 2.13.6

### DIFF
--- a/python-bindings/CMakeLists.txt
+++ b/python-bindings/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11.git
-  GIT_TAG        v2.10.0
+  GIT_TAG        v2.13.6
 )
 FetchContent_MakeAvailable(pybind11)
 


### PR DESCRIPTION
For some reason, building, only inside of dash core, on asahi linux (aarch64 16k page size running on m1 mac pro) failing with errors like:

```
-- pybind11 v2.10.0 
CMake Error at build/_deps/pybind11-src/tools/pybind11NewTools.cmake:189 (python3_add_library):
  Unknown CMake command "python3_add_library".
Call Stack (most recent call first):
  src/dashbls/python-bindings/CMakeLists.txt:16 (pybind11_add_module)
```

when I bump to 2.13.6 it solves this. Really not sure why