### PR TITLE
ci: drop EoL Python 3.7 and 3.8, Go 1.17, replace with Python 3.12, Go 1.22

### DIFF
--- a/.github/workflows/build-binds.yml
+++ b/.github/workflows/build-binds.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        golang: [ '1.17' ]
+        golang: [ '1.22' ]
         python: ['3.9', '3.10', '3.11', '3.12']
 
     steps:

--- a/.github/workflows/build-binds.yml
+++ b/.github/workflows/build-binds.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
         golang: [ '1.17' ]
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Additional Information

* GitHub Actions has refused to work with Python 3.7 on `macos-latest` (14.7), using an `arm64` runner ([build](https://github.com/dashpay/bls-signatures/actions/runs/12151711341/job/33886798487#step:3:50))
* Python 3.7 was declared EoL in June 2023 as was 3.8 in October 2024 ([source](https://devguide.python.org/versions/)). It has instead been replaced with Python 3.12 (shipped with Ubuntu 24.04 `noble`, [source](https://packages.ubuntu.com/noble/python3))
* Python 3.13 currently doesn't work with bindings ([build](https://github.com/dashpay/bls-signatures/actions/runs/12158184297/job/33905556985?pr=103#step:11:956))
* Go 1.12 was EoL in Aug 2022 ([source](https://endoflife.date/go)), replaced with lowest supported Go version, 1.22
