### PR TITLE
fix: gmp detection on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,7 +220,11 @@ case $host in
         GMP_LDFLAGS="-L$gmp_prefix/lib"
       fi
     fi
-  ;;
+    ;;
+  *freebsd*)
+    GMP_CPPFLAGS="-I/usr/local/include"
+    GMP_LDFLAGS="-L/usr/local/lib"
+    ;;
 esac
 
 if test x"$want_backend" = x"auto"; then


### PR DESCRIPTION
Noticed that gmp couldn't be detected on FreeBSD while testing #102. This patch should fix it.