### PR TITLE
bench: make benchmarks a bit more useful

### DIFF
--- a/src/test-bench.cpp
+++ b/src/test-bench.cpp
@@ -148,9 +148,63 @@ void benchFastAggregateVerification() {
     endStopwatch("PopScheme verification", start, numIters);
 }
 
+void benchSerialize() {
+    const int numIters = 5000000;
+    PrivateKey sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+    G1Element pk = sk.GetG1Element();
+    vector<uint8_t> message = sk.GetG1Element().Serialize();
+    G2Element sig = BasicSchemeMPL().Sign(sk, message);
+
+    auto start = startStopwatch();
+    for (int i = 0; i < numIters; i++) {
+        sk.Serialize();
+    }
+    endStopwatch("Serialize PrivateKey", start, numIters);
+
+    start = startStopwatch();
+    for (int i = 0; i < numIters; i++) {
+        pk.Serialize();
+    }
+    endStopwatch("Serialize G1Element", start, numIters);
+
+    start = startStopwatch();
+    for (int i = 0; i < numIters; i++) {
+        sig.Serialize();
+    }
+    endStopwatch("Serialize G2Element", start, numIters);
+}
+
+void benchSerializeToArray() {
+    const int numIters = 5000000;
+    PrivateKey sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+    G1Element pk = sk.GetG1Element();
+    vector<uint8_t> message = sk.GetG1Element().Serialize();
+    G2Element sig = BasicSchemeMPL().Sign(sk, message);
+
+    auto start = startStopwatch();
+    for (int i = 0; i < numIters; i++) {
+        sk.SerializeToArray();
+    }
+    endStopwatch("SerializeToArray PrivateKey", start, numIters);
+
+    start = startStopwatch();
+    for (int i = 0; i < numIters; i++) {
+        pk.SerializeToArray();
+    }
+    endStopwatch("SerializeToArray G1Element", start, numIters);
+
+    start = startStopwatch();
+    for (int i = 0; i < numIters; i++) {
+        sig.SerializeToArray();
+    }
+    endStopwatch("SerializeToArray G2Element", start, numIters);
+}
+
 int main(int argc, char* argv[]) {
     benchSigs();
     benchVerification();
     benchBatchVerification();
     benchFastAggregateVerification();
+    benchSerialize();
+    benchSerializeToArray();
 }

--- a/src/test-bench.cpp
+++ b/src/test-bench.cpp
@@ -31,21 +31,21 @@ using namespace bls;
 void benchSigs() {
     string testName = "Signing";
     const int numIters = 5000;
-    PrivateKey sk = AugSchemeMPL().KeyGen(getRandomSeed());
+    PrivateKey sk = BasicSchemeMPL().KeyGen(getRandomSeed());
     vector<uint8_t> message1 = sk.GetG1Element().Serialize();
 
     auto start = startStopwatch();
 
     for (int i = 0; i < numIters; i++) {
-        AugSchemeMPL().Sign(sk, message1);
+        BasicSchemeMPL().Sign(sk, message1);
     }
     endStopwatch(testName, start, numIters);
 }
 
 void benchVerification() {
     string testName = "Verification";
-    const int numIters = 10000;
-    PrivateKey sk = AugSchemeMPL().KeyGen(getRandomSeed());
+    const int numIters = 1000;
+    PrivateKey sk = BasicSchemeMPL().KeyGen(getRandomSeed());
     G1Element pk = sk.GetG1Element();
 
     std::vector<G2Element> sigs;
@@ -54,7 +54,7 @@ void benchVerification() {
         uint8_t message[4];
         Util::IntToFourBytes(message, i);
         vector<uint8_t> messageBytes(message, message + 4);
-        sigs.push_back(AugSchemeMPL().Sign(sk, messageBytes));
+        sigs.push_back(BasicSchemeMPL().Sign(sk, messageBytes));
     }
 
     auto start = startStopwatch();
@@ -62,34 +62,36 @@ void benchVerification() {
         uint8_t message[4];
         Util::IntToFourBytes(message, i);
         vector<uint8_t> messageBytes(message, message + 4);
-        bool ok = AugSchemeMPL().Verify(pk, messageBytes, sigs[i]);
+        bool ok = BasicSchemeMPL().Verify(pk, messageBytes, sigs[i]);
         ASSERT(ok);
     }
     endStopwatch(testName, start, numIters);
 }
 
 void benchBatchVerification() {
-    const int numIters = 100000;
+    const int numIters = 10000;
 
     vector<vector<uint8_t>> sig_bytes;
     vector<vector<uint8_t>> pk_bytes;
     vector<vector<uint8_t>> ms;
 
+    auto start = startStopwatch();
     for (int i = 0; i < numIters; i++) {
         uint8_t message[4];
         Util::IntToFourBytes(message, i);
         vector<uint8_t> messageBytes(message, message + 4);
-        PrivateKey sk = AugSchemeMPL().KeyGen(getRandomSeed());
+        PrivateKey sk = BasicSchemeMPL().KeyGen(getRandomSeed());
         G1Element pk = sk.GetG1Element();
-        sig_bytes.push_back(AugSchemeMPL().Sign(sk, messageBytes).Serialize());
+        sig_bytes.push_back(BasicSchemeMPL().Sign(sk, messageBytes).Serialize());
         pk_bytes.push_back(pk.Serialize());
         ms.push_back(messageBytes);
     }
+    endStopwatch("Batch verification preparation", start, numIters);
 
     vector<G1Element> pks;
     pks.reserve(numIters);
 
-    auto start = startStopwatch();
+    start = startStopwatch();
     for (auto const& pk : pk_bytes) {
         pks.emplace_back(G1Element::FromBytes(Bytes(pk)));
     }
@@ -105,11 +107,11 @@ void benchBatchVerification() {
     endStopwatch("Signature validation", start, numIters);
 
     start = startStopwatch();
-    G2Element aggSig = AugSchemeMPL().Aggregate(sigs);
+    G2Element aggSig = BasicSchemeMPL().Aggregate(sigs);
     endStopwatch("Aggregation", start, numIters);
 
     start = startStopwatch();
-    bool ok = AugSchemeMPL().AggregateVerify(pks, ms, aggSig);
+    bool ok = BasicSchemeMPL().AggregateVerify(pks, ms, aggSig);
     ASSERT(ok);
     endStopwatch("Batch verification", start, numIters);
 }

--- a/src/test-bench.cpp
+++ b/src/test-bench.cpp
@@ -116,40 +116,6 @@ void benchBatchVerification() {
     endStopwatch("Batch verification", start, numIters);
 }
 
-void benchFastAggregateVerification() {
-    const int numIters = 5000;
-
-    vector<G2Element> sigs;
-    vector<G1Element> pks;
-    vector<uint8_t> message = {1, 2, 3, 4, 5, 6, 7, 8};
-    vector<G2Element> pops;
-
-    for (int i = 0; i < numIters; i++) {
-        PrivateKey sk = PopSchemeMPL().KeyGen(getRandomSeed());
-        G1Element pk = sk.GetG1Element();
-        sigs.push_back(PopSchemeMPL().Sign(sk, message));
-        pops.push_back(PopSchemeMPL().PopProve(sk));
-        pks.push_back(pk);
-    }
-
-    auto start = startStopwatch();
-    G2Element aggSig = PopSchemeMPL().Aggregate(sigs);
-    endStopwatch("PopScheme Aggregation", start, numIters);
-
-
-    start = startStopwatch();
-    for (int i = 0; i < numIters; i++) {
-        bool ok = PopSchemeMPL().PopVerify(pks[i], pops[i]);
-        ASSERT(ok);
-    }
-    endStopwatch("PopScheme Proofs verification", start, numIters);
-
-    start = startStopwatch();
-    bool ok = PopSchemeMPL().FastAggregateVerify(pks, message, aggSig);
-    ASSERT(ok);
-    endStopwatch("PopScheme verification", start, numIters);
-}
-
 void benchSerialize() {
     const int numIters = 5000000;
     PrivateKey sk = BasicSchemeMPL().KeyGen(getRandomSeed());
@@ -206,7 +172,6 @@ int main(int argc, char* argv[]) {
     benchSigs();
     benchVerification();
     benchBatchVerification();
-    benchFastAggregateVerification();
     benchSerialize();
     benchSerializeToArray();
 }


### PR DESCRIPTION
Add serialization benchmarks, use BasicSchemeMPL in existing benchmarks, drop irrelevant ones

<details>
<summary>Results (m1 pro)</summary>

```
Signing
Total: 5000 runs in 3835 ms
Avg: 0.767 ms

Verification
Total: 1000 runs in 2527 ms
Avg: 2.527 ms

Batch verification preparation
Total: 10000 runs in 8786 ms
Avg: 0.8786 ms

Public key validation
Total: 10000 runs in 1896 ms
Avg: 0.1896 ms

Signature validation
Total: 10000 runs in 2048 ms
Avg: 0.2048 ms

Aggregation
Total: 10000 runs in 20 ms
Avg: 0.002 ms

Batch verification
Total: 10000 runs in 11056 ms
Avg: 1.1056 ms

Serialize PrivateKey
Total: 5000000 runs in 134 ms
Avg: 2.68e-05 ms

Serialize G1Element
Total: 5000000 runs in 1036 ms
Avg: 0.0002072 ms

Serialize G2Element
Total: 5000000 runs in 1541 ms
Avg: 0.0003082 ms

SerializeToArray PrivateKey
Total: 5000000 runs in 61 ms
Avg: 1.22e-05 ms

SerializeToArray G1Element
Total: 5000000 runs in 936 ms
Avg: 0.0001872 ms

SerializeToArray G2Element
Total: 5000000 runs in 1444 ms
Avg: 0.0002888 ms
```
</details>