### PR TITLE
chore: bump version to 1.3.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.60])
-AC_INIT([libdashbls],[1.3.4])
+AC_INIT([libdashbls],[1.3.5])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 


### PR DESCRIPTION
## Additional Information

* Depends on https://github.com/dashpay/bls-signatures/pull/106
* Version slated to include [bls-signatures#75](https://github.com/dashpay/bls-signatures/pull/75) and [bls-signatures#106](https://github.com/dashpay/bls-signatures/pull/106)