### PR TITLE
perf: optimize CBLSSignature::VerifySecureAggregated in 2 times

### DIFF
--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -26,7 +26,7 @@ using std::vector;
 
 namespace bls {
 
-static void HashPubKeys(std::vector<bn_t>& computedTs, std::vector<Bytes> vecPubKeyBytes)
+static void HashPubKeys(std::vector<bn_t>& computedTs, const std::vector<std::array<uint8_t, G1Element::SIZE>>& vecPubKeyBytes)
 {
     bn_t order;
     bn_new(order);
@@ -195,19 +195,19 @@ G2Element CoreMPL::AggregateSecure(std::vector<G1Element> const &vecPublicKeys,
     }
 
     std::vector<bn_t> computedTs(vecPublicKeys.size());
-    std::vector<std::pair<vector<uint8_t>, const G2Element*>> vecSorted(vecPublicKeys.size());
+    std::vector<std::pair<std::array<uint8_t, G1Element::SIZE>, const G2Element*>> vecSorted;
     for (size_t i = 0; i < vecPublicKeys.size(); i++) {
         bn_new(computedTs[i]);
-        vecSorted[i] = std::make_pair(vecPublicKeys[i].Serialize(fLegacy), &vecSignatures[i]);
+        vecSorted.emplace_back(vecPublicKeys[i].SerializeToArray(fLegacy), &vecSignatures[i]);
     }
     std::sort(vecSorted.begin(), vecSorted.end(), [](const auto& a, const auto& b) {
         return std::memcmp(a.first.data(), b.first.data(), G1Element::SIZE) < 0;
     });
 
-    std::vector<Bytes> vecPublicKeyBytes;
+    std::vector<std::array<uint8_t, G1Element::SIZE>> vecPublicKeyBytes;
     vecPublicKeyBytes.reserve(vecPublicKeys.size());
     for (const auto& it : vecSorted) {
-        vecPublicKeyBytes.push_back(Bytes{it.first});
+        vecPublicKeyBytes.push_back(it.first);
     }
 
     HashPubKeys(computedTs, vecPublicKeyBytes);
@@ -237,10 +237,10 @@ bool CoreMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
                            const Bytes& message,
                            const bool fLegacy) {
     std::vector<bn_t> computedTs(vecPublicKeys.size());
-    std::vector<vector<uint8_t>> vecSorted(vecPublicKeys.size());
+    std::vector<std::array<uint8_t, G1Element::SIZE>> vecSorted;
     for (size_t i = 0; i < vecPublicKeys.size(); i++) {
         bn_new(computedTs[i]);
-        vecSorted[i] = vecPublicKeys[i].Serialize(fLegacy);
+        vecSorted.emplace_back(vecPublicKeys[i].SerializeToArray(fLegacy));
     }
     std::sort(vecSorted.begin(), vecSorted.end(), [](const auto& a, const auto& b) -> bool {
         return std::memcmp(a.data(), b.data(), G1Element::SIZE) < 0;

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -26,7 +26,7 @@ using std::vector;
 
 namespace bls {
 
-static void HashPubKeys(bn_t* computedTs, std::vector<Bytes> vecPubKeyBytes)
+static void HashPubKeys(std::vector<bn_t>& computedTs, std::vector<Bytes> vecPubKeyBytes)
 {
     bn_t order;
     bn_new(order);
@@ -194,7 +194,7 @@ G2Element CoreMPL::AggregateSecure(std::vector<G1Element> const &vecPublicKeys,
         throw std::invalid_argument("LegacySchemeMPL::AggregateSigs sigs.size() != pubKeys.size()");
     }
 
-    bn_t* computedTs = new bn_t[vecPublicKeys.size()];
+    std::vector<bn_t> computedTs(vecPublicKeys.size());
     std::vector<std::pair<vector<uint8_t>, const G2Element*>> vecSorted(vecPublicKeys.size());
     for (size_t i = 0; i < vecPublicKeys.size(); i++) {
         bn_new(computedTs[i]);
@@ -218,11 +218,10 @@ G2Element CoreMPL::AggregateSecure(std::vector<G1Element> const &vecPublicKeys,
     expSigs.reserve(vecSorted.size());
     for (size_t i = 0; i < vecSorted.size(); i++) {
         expSigs.emplace_back(*vecSorted[i].second * computedTs[i]);
+        bn_free(computedTs[i]);
     }
 
     G2Element aggSig = CoreMPL::Aggregate(expSigs);
-
-    delete[] computedTs;
 
     return aggSig;
 }
@@ -237,12 +236,7 @@ bool CoreMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
                            const G2Element& signature,
                            const Bytes& message,
                            const bool fLegacy) {
-    bn_t one;
-    bn_new(one);
-    bn_zero(one);
-    bn_set_dig(one, 1);
-
-    bn_t* computedTs = new bn_t[vecPublicKeys.size()];
+    std::vector<bn_t> computedTs(vecPublicKeys.size());
     std::vector<vector<uint8_t>> vecSorted(vecPublicKeys.size());
     for (size_t i = 0; i < vecPublicKeys.size(); i++) {
         bn_new(computedTs[i]);
@@ -258,10 +252,8 @@ bool CoreMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
     for (size_t i = 0; i < vecSorted.size(); ++i) {
         G1Element g1 = G1Element::FromBytes(Bytes(vecSorted[i]), fLegacy);
         publicKey = CoreMPL::Aggregate({publicKey, g1 * computedTs[i]});
+        bn_free(computedTs[i]);
     }
-
-    bn_free(one);
-    delete[] computedTs;
 
     return AggregateVerify({publicKey}, {message}, {signature});
 }

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -26,7 +26,8 @@ using std::vector;
 
 namespace bls {
 
-static void HashPubKeys(std::vector<bn_t>& computedTs, const std::vector<std::array<uint8_t, G1Element::SIZE>>& vecPubKeyBytes)
+template<class T>
+static void HashPubKeys(std::vector<bn_t>& computedTs, const std::vector<std::pair<std::array<uint8_t, G1Element::SIZE>, const T*>>& vecPubKeyBytes)
 {
     bn_t order;
     bn_new(order);
@@ -35,7 +36,7 @@ static void HashPubKeys(std::vector<bn_t>& computedTs, const std::vector<std::ar
     std::vector<uint8_t> vecBuffer(vecPubKeyBytes.size() * G1Element::SIZE);
 
     for (size_t i = 0; i < vecPubKeyBytes.size(); i++) {
-        memcpy(vecBuffer.data() + i * G1Element::SIZE, vecPubKeyBytes[i].begin(), G1Element::SIZE);
+        memcpy(vecBuffer.data() + i * G1Element::SIZE, vecPubKeyBytes[i].first.begin(), G1Element::SIZE);
     }
 
     uint8_t pkHash[32];
@@ -204,13 +205,7 @@ G2Element CoreMPL::AggregateSecure(std::vector<G1Element> const &vecPublicKeys,
         return std::memcmp(a.first.data(), b.first.data(), G1Element::SIZE) < 0;
     });
 
-    std::vector<std::array<uint8_t, G1Element::SIZE>> vecPublicKeyBytes;
-    vecPublicKeyBytes.reserve(vecPublicKeys.size());
-    for (const auto& it : vecSorted) {
-        vecPublicKeyBytes.push_back(it.first);
-    }
-
-    HashPubKeys(computedTs, vecPublicKeyBytes);
+    HashPubKeys(computedTs, vecSorted);
 
     // Raise all signatures to power of the corresponding t's and aggregate the results into aggSig
     // Also accumulates aggregation info for each signature
@@ -237,21 +232,20 @@ bool CoreMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
                            const Bytes& message,
                            const bool fLegacy) {
     std::vector<bn_t> computedTs(vecPublicKeys.size());
-    std::vector<std::array<uint8_t, G1Element::SIZE>> vecSorted;
+    std::vector<std::pair<std::array<uint8_t, G1Element::SIZE>, const G1Element*>> vecSorted;
     for (size_t i = 0; i < vecPublicKeys.size(); i++) {
         bn_new(computedTs[i]);
-        vecSorted.emplace_back(vecPublicKeys[i].SerializeToArray(fLegacy));
+        vecSorted.emplace_back(vecPublicKeys[i].SerializeToArray(fLegacy), &vecPublicKeys[i]);
     }
     std::sort(vecSorted.begin(), vecSorted.end(), [](const auto& a, const auto& b) -> bool {
-        return std::memcmp(a.data(), b.data(), G1Element::SIZE) < 0;
+        return std::memcmp(a.first.data(), b.first.data(), G1Element::SIZE) < 0;
     });
 
-    HashPubKeys(computedTs, {vecSorted.begin(), vecSorted.end()});
+    HashPubKeys(computedTs, vecSorted);
 
     G1Element publicKey;
     for (size_t i = 0; i < vecSorted.size(); ++i) {
-        G1Element g1 = G1Element::FromBytes(Bytes(vecSorted[i]), fLegacy);
-        publicKey = CoreMPL::Aggregate({publicKey, g1 * computedTs[i]});
+        publicKey = CoreMPL::Aggregate({publicKey, (*vecSorted[i].second) * computedTs[i]});
         bn_free(computedTs[i]);
     }
 


### PR DESCRIPTION
Current implementation of `CoreMPL::VerifySecure` does serialization and deserialization of G1 element.
    
Deserialization is very heavy because FromBytes() also validates that G1 is valid.
This validation is very expensive for computation power but useless because we already know that object is valid.
Much better to keep pointer to original object.
    
This PR to dashbls speeds up validation of quorum commitment in Dash Core in 2 times which make indexing and validating new blocks overall 11% faster.
The performance improvement is most noticeable on blocks that have rotation quorum commitment, because one block has 32 commitments. 


Benchmarks has been done on 15000 last blocks.

Dash Core with this PR:
<img width="695" alt="image" src="https://github.com/user-attachments/assets/ca6439cd-aef3-4c22-be1a-423b33376544" />

```
2025-05-26T07:35:21Z [bench]         - m_qblockman: 0.05ms [55.43s]
2025-05-26T07:35:21Z [bench]   - Connect total: 19.96ms [223.70s (14.40ms/blk)]
2025-05-26T07:35:21Z [bench] - Connect block: 20.46ms [230.66s (14.85ms/blk)]
```


Dash Core with current master:
<img width="695" alt="image" src="https://github.com/user-attachments/assets/4708ebd4-e17b-4e8d-bf67-ebc1d4861fca" />

```
2025-05-22T18:39:44Z [bench]         - m_qblockman: 0.03ms [96.90s]
2025-05-22T18:39:44Z [bench]   - Connect total: 9.31ms [252.80s (16.28ms/blk)]
2025-05-22T18:39:44Z [bench] - Connect block: 9.50ms [258.90s (16.67ms/blk)]
```