### PR TITLE
chore: update cmake

### DIFF
--- a/depends/mimalloc/CMakeLists.txt
+++ b/depends/mimalloc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 project(libmimalloc C CXX)
 
 set(CMAKE_C_STANDARD 11)

--- a/depends/mimalloc/test/CMakeLists.txt
+++ b/depends/mimalloc/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 project(mimalloc-test C CXX)
 
 set(CMAKE_C_STANDARD 11)

--- a/depends/relic/CMakeLists.txt
+++ b/depends/relic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.14)
 if(NOT ${CMAKE_VERSION} VERSION_LESS "3.1")
 	cmake_policy(SET CMP0054 NEW)
 endif()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the minimum required CMake version to 3.14 across bundled third‑party components and their tests to align build tooling and improve consistency on modern environments.
  * No functional or API changes; runtime behavior remains unchanged.
  * Developers building from source now need CMake 3.14+ to configure the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->