### PR TITLE
build: remove explicit libssp linking from Windows build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -772,12 +772,6 @@ if test "$use_hardening" != "no"; then
   AX_CHECK_LINK_FLAG([-Wl,-z,now], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,now"], [], [])
   AX_CHECK_LINK_FLAG([-Wl,-z,separate-code], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,separate-code"], [], [])
   AX_CHECK_LINK_FLAG([-fPIE -pie], [HARDENED_FLAGS="$HARDENED_FLAGS -fPIE"; HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"], [], [])
-
-  case $host in
-    *mingw*)
-       AC_CHECK_LIB([ssp], [main], [], [AC_MSG_ERROR([libssp missing])])
-    ;;
-  esac
 fi
 
 CORE_CPPFLAGS="$CORE_CPPFLAGS -DHAVE_BUILD_INFO"


### PR DESCRIPTION
## Additional Information

* This change is a counterpart to [`8f43302`](https://github.com/bitcoin/bitcoin/commit/8f43302a0a1bb79129933e4cc174bf8d8d59ec15) from [bitcoin#28461](https://github.com/bitcoin/bitcoin/pull/28461)

* Required to resolve build failures using Guix (see below) when paired with [dash#6889](https://github.com/dashpay/dash/pull/6889)

  <details>

  <summary>Build failure:</summary>

  ```
  x86_64-w64-mingw32-ld: /gnu/store/jiiy3vkhajmi1lyxcvq5x3l82i6f9agf-gcc-cross-x86_64-w64-mingw32-12.4.0-lib/x86_64-w64-mingw32/lib/../lib/libssp.a(ssp.o):(.text+0xf0): multiple definition of `__stack_chk_fail'; /gnu/store/jiiy3vkhajmi1lyxcvq5x3l82i6f9agf-gcc-cross-x86_64-w64-mingw32-12.4.0-lib/x86_64-w64-mingw32/lib/../lib/libssp.dll.a(libssp_0_dll_d000007.o):(.text+0x0): first defined here
    CXX      masternode/libbitcoin_node_a-sync.o
    CXX      masternode/libbitcoin_node_a-utils.o
    CXX      node/libbitcoin_node_a-blockstorage.o
  collect2: error: ld returned 1 exit status
  make[3]: *** [Makefile:3247: runtest.exe] Error 1
  make[3]: Leaving directory '/distsrc-base/distsrc-23.0.0-rc.1-8-g32ad4a7b3885-x86_64-w64-mingw32/src/dashbls'
  make[2]: *** [Makefile:23826: dashbls/libdashbls.la] Error 2
  make[2]: *** Waiting for unfinished jobs....
  make[2]: Leaving directory '/distsrc-base/distsrc-23.0.0-rc.1-8-g32ad4a7b3885-x86_64-w64-mingw32/src'
  make[1]: *** [Makefile:21421: all-recursive] Error 1
  make[1]: Leaving directory '/distsrc-base/distsrc-23.0.0-rc.1-8-g32ad4a7b3885-x86_64-w64-mingw32/src'
  make: *** [Makefile:793: all-recursive] Error 1
  ```

  </details> 