### PR TITLE
build: ensure `LINK_FLAG` propagation, enable MacPorts/Homebrew awareness for Go builds, enable WASM debug runtime assertions, bump Go, add Rust to matrix

### DIFF
--- a/.github/workflows/build-binds.yml
+++ b/.github/workflows/build-binds.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   build:
-    name: ${{ matrix.os }}, Python ${{ matrix.python }}, Go ${{ matrix.golang }}
+    name: ${{ matrix.os }}, Python ${{ matrix.python }}, Go ${{ matrix.golang }}, Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,6 +25,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
         golang: [ '1.22' ]
         python: ['3.10', '3.11', '3.12', '3.13']
+        rust: [ '1.91.0' ]
 
     steps:
     - name: Checkout code
@@ -83,3 +84,15 @@ jobs:
         cd go-bindings
         make config
         make
+
+    - name: Install Rust
+      run: |
+        rustup toolchain install ${{ matrix.rust }}
+        rustup default ${{ matrix.rust }}
+        rustc --version
+        cargo --version
+
+    - name: Build and test Rust bindings
+      run: |
+        cd rust-bindings/bls-dash-sys
+        cargo test

--- a/.github/workflows/build-binds.yml
+++ b/.github/workflows/build-binds.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        golang: [ '1.22' ]
+        golang: [ '1.24' ]
         python: ['3.10', '3.11', '3.12', '3.13']
         rust: [ '1.91.0' ]
 

--- a/.github/workflows/build-binds.yml
+++ b/.github/workflows/build-binds.yml
@@ -81,4 +81,5 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         cd go-bindings
+        make config
         make

--- a/.github/workflows/build-binds.yml
+++ b/.github/workflows/build-binds.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
         golang: [ '1.22' ]
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/build-binds.yml
+++ b/.github/workflows/build-binds.yml
@@ -78,8 +78,6 @@ jobs:
         cmake --build . -- -j 6
 
     - name: Build Go bindings
-      # TODO: macos build is broken. Whoever needs this - please fix it and remove `if` below.
-      if: startsWith(matrix.os, 'ubuntu')
       run: |
         cd go-bindings
         make config

--- a/go-bindings/Makefile
+++ b/go-bindings/Makefile
@@ -1,6 +1,9 @@
 GO="go"
 CGO_ENABLED := 1
 
+OS := $(shell uname -s)
+ARCH := $(shell uname -m)
+
 COVERAGE_OUTPUT ?= coverage.out
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
@@ -9,19 +12,37 @@ BUILD_DIR=$(PWD)/../build
 CURR_DIR := $(dir $(MAKEFILE_PATH))
 SRC_DIR=$(PWD)/../src
 
+GMP_PREFIX := /usr/local
+
+ifeq ("$(OS)", "Darwin")
+  ifneq ($(wildcard /opt/local/bin/port),)
+    GMP_PREFIX := /opt/local
+  endif
+  ifeq ("$(ARCH)", "arm64")
+    ifneq ($(wildcard /opt/homebrew/bin/brew),)
+      GMP_PREFIX := /opt/homebrew
+    endif
+  endif
+else ifeq ("$(OS)", "Linux")
+  ifneq ($(wildcard /home/linuxbrew/.linuxbrew/bin/brew),)
+    GMP_PREFIX := /home/linuxbrew/.linuxbrew
+  endif
+endif
+
 CGO_CXXFLAGS ?= "\
 -I$(CURR_DIR)../build/depends/relic/include \
 -I$(CURR_DIR)../depends/mimalloc/include \
 -I$(CURR_DIR)../depends/relic/include \
--I$(CURR_DIR)../include"
+-I$(CURR_DIR)../include \
+-I$(GMP_PREFIX)/include"
 
 CGO_LDFLAGS ?= "\
--L$(CURR_DIR)../build/depends/mimalloc \
--L$(CURR_DIR)../build/depends/relic/lib \
--L$(CURR_DIR)../build/src \
--ldashbls -lrelic_s -lmimalloc-secure -lgmp"
+-L$(CURR_DIR)../build/depends/mimalloc -lmimalloc-secure \
+-L$(CURR_DIR)../build/depends/relic/lib -lrelic_s \
+-L$(CURR_DIR)../build/src -ldashbls \
+-L$(GMP_PREFIX)/lib -lgmp"
 
-.PHONY: default vet test clean
+.PHONY: default vet test clean config
 
 default: prepare vet test clean
 
@@ -50,3 +71,18 @@ help: ## Show This Help
 clean: ## Clean up transient (generated) files
 	$(GO) clean
 	rm -f $(COVERAGE_OUTPUT)
+
+config: ## Display build configuration
+	@echo ""
+	@echo "OS:           $(OS)"
+	@echo "ARCH:         $(ARCH)"
+	@echo ""
+	@echo "CC:           $${CC:-<not set>}"
+	@echo "CXX:          $${CXX:-<not set>}"
+	@echo "GO:           $(GO)"
+	@echo ""
+	@echo "GOROOT:       $${GOROOT:-<not set>}"
+	@echo ""
+	@echo "CGO_CXXFLAGS: $(CGO_CXXFLAGS)"
+	@echo "CGO_LDFLAGS:  $(CGO_LDFLAGS)"
+	@echo ""

--- a/go-bindings/Makefile
+++ b/go-bindings/Makefile
@@ -1,17 +1,19 @@
-SRC_DIR=$(PWD)/../src
-BUILD_DIR=$(PWD)/../build
-
 GO="go"
+CGO_ENABLED := 1
+
 COVERAGE_OUTPUT ?= coverage.out
 
-.PHONY: default vet test clean
-
-default: prepare vet test clean
-
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-CURR_DIR := $(dir $(MAKEFILE_PATH))
 
-CGO_ENABLED := 1
+BUILD_DIR=$(PWD)/../build
+CURR_DIR := $(dir $(MAKEFILE_PATH))
+SRC_DIR=$(PWD)/../src
+
+CGO_CXXFLAGS ?= "\
+-I$(CURR_DIR)../build/depends/relic/include \
+-I$(CURR_DIR)../depends/mimalloc/include \
+-I$(CURR_DIR)../depends/relic/include \
+-I$(CURR_DIR)../include"
 
 CGO_LDFLAGS ?= "\
 -L$(CURR_DIR)../build/depends/mimalloc \
@@ -19,11 +21,9 @@ CGO_LDFLAGS ?= "\
 -L$(CURR_DIR)../build/src \
 -ldashbls -lrelic_s -lmimalloc-secure -lgmp"
 
-CGO_CXXFLAGS ?= "\
--I$(CURR_DIR)../build/depends/relic/include \
--I$(CURR_DIR)../depends/mimalloc/include \
--I$(CURR_DIR)../depends/relic/include \
--I$(CURR_DIR)../include"
+.PHONY: default vet test clean
+
+default: prepare vet test clean
 
 prepare:
 	@mkdir -p ../build/src/dashbls

--- a/go-bindings/Makefile
+++ b/go-bindings/Makefile
@@ -1,5 +1,5 @@
-GO="go"
-CGO_ENABLED := 1
+export CGO_ENABLED := 1
+GO=go
 
 OS := $(shell uname -s)
 ARCH := $(shell uname -m)
@@ -8,9 +8,9 @@ COVERAGE_OUTPUT ?= coverage.out
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 
-BUILD_DIR=$(PWD)/../build
+BUILD_DIR=$(CURDIR)/../build
 CURR_DIR := $(dir $(MAKEFILE_PATH))
-SRC_DIR=$(PWD)/../src
+SRC_DIR=$(CURDIR)/../src
 
 GMP_PREFIX := /usr/local
 
@@ -37,12 +37,14 @@ CGO_CXXFLAGS ?= "\
 -I$(GMP_PREFIX)/include"
 
 CGO_LDFLAGS ?= "\
+-L$(CURR_DIR)../build/src -ldashbls \
 -L$(CURR_DIR)../build/depends/mimalloc -lmimalloc-secure \
 -L$(CURR_DIR)../build/depends/relic/lib -lrelic_s \
--L$(CURR_DIR)../build/src -ldashbls \
 -L$(GMP_PREFIX)/lib -lgmp"
 
-.PHONY: default vet test clean config
+.PHONY: default prepare fmt test cover vet help clean config
+
+all: default
 
 default: prepare vet test clean
 
@@ -63,7 +65,7 @@ cover:  ## Run tests and generate test coverage file, output coverage results an
 	rm -f $(COVERAGE_OUTPUT)
 
 vet:  ## Go vet all project code
-	CGO_CXXFLAGS=$(CGO_CXXFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) go vet ./...
+	CGO_CXXFLAGS=$(CGO_CXXFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) $(GO) vet ./...
 
 help: ## Show This Help
 	@for line in $$(cat Makefile | grep "##" | grep -v "grep" | sed  "s/:.*##/:/g" | sed "s/\ /!/g"); do verb=$$(echo $$line | cut -d ":" -f 1); desc=$$(echo $$line | cut -d ":" -f 2 | sed "s/!/\ /g"); printf "%-30s--%s\n" "$$verb" "$$desc"; done

--- a/go-bindings/elements.go
+++ b/go-bindings/elements.go
@@ -14,8 +14,6 @@
 
 package blschia
 
-// #cgo LDFLAGS: -ldashbls -lrelic_s -lmimalloc-secure -lgmp
-// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "elements.h"

--- a/go-bindings/privatekey.go
+++ b/go-bindings/privatekey.go
@@ -14,8 +14,6 @@
 
 package blschia
 
-// #cgo LDFLAGS: -ldashbls -lrelic_s -lmimalloc-secure -lgmp
-// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "privatekey.h"

--- a/go-bindings/schemes.go
+++ b/go-bindings/schemes.go
@@ -14,8 +14,6 @@
 
 package blschia
 
-// #cgo LDFLAGS: -ldashbls -lrelic_s -lmimalloc-secure -lgmp
-// #cgo CXXFLAGS: -std=c++14
 // #include <stdbool.h>
 // #include <stdlib.h>
 // #include "schemes.h"

--- a/go-bindings/threshold.go
+++ b/go-bindings/threshold.go
@@ -14,8 +14,6 @@
 
 package blschia
 
-// #cgo LDFLAGS: -ldashbls -lrelic_s -lmimalloc-secure -lgmp
-// #cgo CXXFLAGS: -std=c++14
 // #include <stdlib.h>
 // #include "threshold.h"
 // #include "blschia.h"

--- a/go-bindings/util.go
+++ b/go-bindings/util.go
@@ -14,8 +14,6 @@
 
 package blschia
 
-// #cgo LDFLAGS: -ldashbls -lrelic_s -lmimalloc-secure -lgmp
-// #cgo CXXFLAGS: -std=c++14
 // #include "blschia.h"
 // #include <string.h>
 import "C"

--- a/js-bindings/CMakeLists.txt
+++ b/js-bindings/CMakeLists.txt
@@ -20,6 +20,13 @@ add_custom_target(install_npm_dependencies npm ci)
 add_dependencies(blsjstmp install_npm_dependencies)
 target_link_libraries(blsjstmp PRIVATE dashbls)
 
+target_link_options(blsjstmp PRIVATE
+    "SHELL:--bind"
+    "SHELL:-Oz"
+    "SHELL:--closure 1"
+    "SHELL:-s MODULARIZE=1"
+)
+
 # Copy necessary files for the npm package
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/package.json package.json COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json package-lock.json COPYONLY)
@@ -34,5 +41,4 @@ foreach(file ${JS_BINDINGS_TESTS})
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/${file} tests/${file} COPYONLY)
 endforeach()
 
-set_target_properties(blsjstmp PROPERTIES LINK_FLAGS "--bind -Oz --closure 1 -s MODULARIZE=1")
 add_custom_command(TARGET blsjstmp POST_BUILD COMMAND npm run build:web)

--- a/js-bindings/CMakeLists.txt
+++ b/js-bindings/CMakeLists.txt
@@ -27,6 +27,10 @@ target_link_options(blsjstmp PRIVATE
     "SHELL:-s MODULARIZE=1"
 )
 
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    target_link_options(blsjstmp PRIVATE "SHELL:-s ASSERTIONS=2")
+endif()
+
 # Copy necessary files for the npm package
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/package.json package.json COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json package-lock.json COPYONLY)

--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -25,6 +25,16 @@
 namespace py = pybind11;
 using namespace bls;
 
+namespace {
+inline int PyLong_AsByteArray(PyLongObject* obj, uint8_t* buf, Py_ssize_t size, bool is_le, bool is_signed)
+{
+    return _PyLong_AsByteArray(obj, buf, size, is_le, is_signed
+#if PY_VERSION_HEX >= 0x030d0000
+                               , /*with_exceptions=*/true
+#endif // PY_VERSION_HEX >= 0x030d0000
+    );
+}
+} // anonymous namespace
 
 PYBIND11_MODULE(blspy, m)
 {
@@ -357,7 +367,7 @@ PYBIND11_MODULE(blspy, m)
         .def(py::init(&G1Element::FromByteVector), py::call_guard<py::gil_scoped_release>())
         .def(py::init([](py::int_ pyint) {
             std::array<uint8_t, G1Element::SIZE> buffer{};
-            if (_PyLong_AsByteArray(
+            if (PyLong_AsByteArray(
                     (PyLongObject *)pyint.ptr(),
                     buffer.data(),
                     buffer.size(),
@@ -515,7 +525,7 @@ PYBIND11_MODULE(blspy, m)
         }))
         .def(py::init([](py::int_ pyint) {
             std::array<uint8_t, G2Element::SIZE> buffer{};
-            if (_PyLong_AsByteArray(
+            if (PyLong_AsByteArray(
                     (PyLongObject *)pyint.ptr(),
                     buffer.data(),
                     buffer.size(),
@@ -647,7 +657,7 @@ PYBIND11_MODULE(blspy, m)
         }))
         .def(py::init([](py::int_ pyint) {
             std::array<uint8_t, GTElement::SIZE> buffer{};
-            if (_PyLong_AsByteArray(
+            if (PyLong_AsByteArray(
                     (PyLongObject *)pyint.ptr(),
                     buffer.data(),
                     buffer.size(),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,9 +46,21 @@ if(BUILD_BLS_TESTS)
   target_link_libraries(runtest
                         PRIVATE dashbls
                         PRIVATE catch2)
+
+  if(EMSCRIPTEN)
+    if(CMAKE_BUILD_TYPE MATCHES "Debug")
+      target_link_options(runtest PRIVATE "SHELL:-s ASSERTIONS=2")
+    endif()
+  endif()
 endif()
 
 if(BUILD_BLS_BENCHMARKS)
   add_executable(runbench test-bench.cpp)
   target_link_libraries(runbench PRIVATE dashbls)
+
+  if(EMSCRIPTEN)
+    if(CMAKE_BUILD_TYPE MATCHES "Debug")
+      target_link_options(runbench PRIVATE "SHELL:-s ASSERTIONS=2")
+    endif()
+  endif()
 endif()


### PR DESCRIPTION
## Additional Information

* Our current binds action does not compile and test the Rust bindings, we will test against the latest available version of Rust as of this writing, 1.91 ([source](https://endoflife.date/rust)). This is to ensure we are testing all binds in active use.

* Python 3.9's security support elapsed on 31st Oct '25 ([source](https://endoflife.date/python)). In response to that, we have updated the build matrix to move one minor version ahead.

  * Python 3.13 made breaking changes that affect our usage of the `_PyLong_AsByteArray()` private API ([source](https://github.com/python/cpython/issues/111140)), which has necessitated the introduction of a wrapper to deal with the modified function signature.

    * We are opting to continue to use the private API instead of the newly introduced `PyLong_AsNativeBytes()` as we are still testing against versions of Python that do not have it. We should consider moving over to the public API when Python 3.13 is the minimum tested version.

* Go 1.22's support period lapsed 11th Feb '25 ([source](https://endoflife.date/go)), so we are bumping the minor version to the lowest still-supported version of Go.

* The Go binds are now Homebrew/MacPorts aware, which is necessary as `libdashbls` is dependent on `libgmp`, which is **not** a vendored dependency and must be installed in the build environment. 

  * The `#cgo` definitions have been removed as it assumes that `libdashbls` is installed on the system and the build environment is Homebrew/MacPorts-aware, neither is true. This also solidifies the usage of the `Makefile` as the sole supported means of building the Go bindings.

  * The variables inherited/configured by the Makefile can be printed using `make config`

* `LINK_FLAGS` defined for `blsjstmp` have **not** been propagating to the build, this has been resolved by using `target_link_options` and `SHELL:` to avoid mangling by CMake.
  * Additional `target_link_options` have been added (`-s ASSERTIONS=2`) to ease debugging when using `Debug` builds when targeting Emscripten/WASM.

## Breaking Changes

None expected.
