### PR TITLE
fix!: pass the actual size of the buffer from the {Go,Rust} bindings

### DIFF
--- a/go-bindings/elements.cpp
+++ b/go-bindings/elements.cpp
@@ -23,11 +23,11 @@ int CG1ElementSize() {
     return bls::G1Element::SIZE;
 }
 
-CG1Element CG1ElementFromBytes(const void* data, bool* didErr) {
+CG1Element CG1ElementFromBytes(const void* data, size_t len, bool* didErr) {
     bls::G1Element* el = nullptr;
     try {
         el = new bls::G1Element(
-            bls::G1Element::FromBytes(bls::Bytes((uint8_t*)(data), bls::G1Element::SIZE))
+            bls::G1Element::FromBytes(bls::Bytes((uint8_t*)data, len))
         );
     } catch(const std::exception& ex) {
         gErrMsg = ex.what();
@@ -93,11 +93,11 @@ int CG2ElementSize() {
     return bls::G2Element::SIZE;
 }
 
-CG2Element CG2ElementFromBytes(const void* data, bool* didErr) {
+CG2Element CG2ElementFromBytes(const void* data, size_t len, bool* didErr) {
     bls::G2Element* el = nullptr;
     try {
         el = new bls::G2Element(
-            bls::G2Element::FromBytes(bls::Bytes((uint8_t*)data, bls::G2Element::SIZE))
+            bls::G2Element::FromBytes(bls::Bytes((uint8_t*)data, len))
         );
         *didErr = false;
     } catch(const std::exception& ex) {

--- a/go-bindings/elements.go
+++ b/go-bindings/elements.go
@@ -40,7 +40,7 @@ func G1ElementFromBytes(data []byte) (*G1Element, error) {
 	defer C.free(cBytesPtr)
 	var cDidErr C.bool
 	el := G1Element{
-		val: C.CG1ElementFromBytes(cBytesPtr, &cDidErr),
+		val: C.CG1ElementFromBytes(cBytesPtr, C.size_t(len(data)), &cDidErr),
 	}
 	if bool(cDidErr) {
 		return nil, errFromC()
@@ -131,7 +131,7 @@ func G2ElementFromBytes(data []byte) (*G2Element, error) {
 	defer C.free(cBytesPtr)
 	var cDidErr C.bool
 	el := G2Element{
-		val: C.CG2ElementFromBytes(cBytesPtr, &cDidErr),
+		val: C.CG2ElementFromBytes(cBytesPtr, C.size_t(len(data)), &cDidErr),
 	}
 	if bool(cDidErr) {
 		return nil, errFromC()

--- a/go-bindings/elements.h
+++ b/go-bindings/elements.h
@@ -27,7 +27,7 @@ typedef void* CPrivateKey;
 
 // G1Element
 int CG1ElementSize();
-CG1Element CG1ElementFromBytes(const void* data, bool* didErr);
+CG1Element CG1ElementFromBytes(const void* data, size_t len, bool* didErr);
 CG1Element CG1ElementGenerator();
 bool CG1ElementIsValid(const CG1Element el);
 uint32_t CG1ElementGetFingerprint(const CG1Element el);
@@ -40,7 +40,7 @@ void CG1ElementFree(const CG1Element el);
 
 // G2Element
 int CG2ElementSize();
-CG2Element CG2ElementFromBytes(const void* data, bool* didErr);
+CG2Element CG2ElementFromBytes(const void* data, size_t len, bool* didErr);
 CG2Element CG2ElementGenerator();
 bool CG2ElementIsValid(const CG2Element el);
 bool CG2ElementIsEqual(const CG2Element el1, const CG2Element el2);

--- a/go-bindings/privatekey.cpp
+++ b/go-bindings/privatekey.cpp
@@ -20,12 +20,12 @@
 #include "utils.hpp"
 
 // private key bindings implementation
-CPrivateKey CPrivateKeyFromBytes(const void* data, const bool modOrder, bool* didErr) {
+CPrivateKey CPrivateKeyFromBytes(const void* data, size_t len, const bool modOrder, bool* didErr) {
     bls::PrivateKey* skPtr = nullptr;
     try {
         skPtr = new bls::PrivateKey(
             bls::PrivateKey::FromBytes(
-                bls::Bytes((uint8_t*)data, bls::PrivateKey::PRIVATE_KEY_SIZE),
+                bls::Bytes((uint8_t*)data, len),
                 modOrder
             )
         );

--- a/go-bindings/privatekey.go
+++ b/go-bindings/privatekey.go
@@ -38,7 +38,7 @@ func PrivateKeyFromBytes(data []byte, modOrder bool) (*PrivateKey, error) {
 	defer C.SecFree(cBytesPtr)
 	var cDidErr C.bool
 	sk := PrivateKey{
-		val: C.CPrivateKeyFromBytes(cBytesPtr, C.bool(modOrder), &cDidErr),
+		val: C.CPrivateKeyFromBytes(cBytesPtr, C.size_t(len(data)), C.bool(modOrder), &cDidErr),
 	}
 	if bool(cDidErr) {
 		return nil, errFromC()

--- a/go-bindings/privatekey.h
+++ b/go-bindings/privatekey.h
@@ -23,7 +23,7 @@ extern "C" {
 
 typedef void* CPrivateKey;
 
-CPrivateKey CPrivateKeyFromBytes(const void* data, const bool modOrder, bool* didErr);
+CPrivateKey CPrivateKeyFromBytes(const void* data, size_t len, const bool modOrder, bool* didErr);
 CPrivateKey CPrivateKeyAggregate(void** sks, const size_t len);
 CG1Element CPrivateKeyGetG1Element(const CPrivateKey sk, bool* didErr);
 CG2Element CPrivateKeyGetG2Element(const CPrivateKey sk, bool* didErr);

--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -46,7 +46,7 @@ PYBIND11_MODULE(blspy, m)
                 }
                 auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
                 std::array<uint8_t, PrivateKey::PRIVATE_KEY_SIZE> data;
-                std::copy(data_ptr, data_ptr + PrivateKey::PRIVATE_KEY_SIZE, data.data());
+                std::copy(data_ptr, data_ptr + data.size(), data.data());
                 py::gil_scoped_release release;
                 return PrivateKey::FromBytes(data);
             })
@@ -360,7 +360,7 @@ PYBIND11_MODULE(blspy, m)
             if (_PyLong_AsByteArray(
                     (PyLongObject *)pyint.ptr(),
                     buffer.data(),
-                    G1Element::SIZE,
+                    buffer.size(),
                     0,
                     0) < 0) {
                 throw std::invalid_argument("Failed to cast int to G1Element");
@@ -380,7 +380,7 @@ PYBIND11_MODULE(blspy, m)
             }
             auto data_ptr = static_cast<uint8_t *>(info.ptr);
             std::array<uint8_t, G1Element::SIZE> data;
-            std::copy(data_ptr, data_ptr + G1Element::SIZE, data.data());
+            std::copy(data_ptr, data_ptr + data.size(), data.data());
             py::gil_scoped_release release;
             return G1Element::FromBytes(data);
         }))
@@ -398,7 +398,7 @@ PYBIND11_MODULE(blspy, m)
                 }
                 auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
                 std::array<uint8_t, G1Element::SIZE> data;
-                std::copy(data_ptr, data_ptr + G1Element::SIZE, data.data());
+                std::copy(data_ptr, data_ptr + data.size(), data.data());
                 py::gil_scoped_release release;
                 return G1Element::FromBytes(data);
             })
@@ -509,7 +509,7 @@ PYBIND11_MODULE(blspy, m)
             }
             auto data_ptr = static_cast<uint8_t *>(info.ptr);
             std::array<uint8_t, G2Element::SIZE> data;
-            std::copy(data_ptr, data_ptr + G2Element::SIZE, data.data());
+            std::copy(data_ptr, data_ptr + data.size(), data.data());
             py::gil_scoped_release release;
             return G2Element::FromBytes(data);
         }))
@@ -518,7 +518,7 @@ PYBIND11_MODULE(blspy, m)
             if (_PyLong_AsByteArray(
                     (PyLongObject *)pyint.ptr(),
                     buffer.data(),
-                    G2Element::SIZE,
+                    buffer.size(),
                     0,
                     0) < 0) {
                 throw std::invalid_argument("Failed to cast int to G2Element");
@@ -540,7 +540,7 @@ PYBIND11_MODULE(blspy, m)
                 }
                 auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
                 std::array<uint8_t, G2Element::SIZE> data;
-                std::copy(data_ptr, data_ptr + G2Element::SIZE, data.data());
+                std::copy(data_ptr, data_ptr + data.size(), data.data());
                 py::gil_scoped_release release;
                 return G2Element::FromBytes(data);
             })
@@ -641,7 +641,7 @@ PYBIND11_MODULE(blspy, m)
             }
             auto data_ptr = static_cast<uint8_t *>(info.ptr);
             std::array<uint8_t, GTElement::SIZE> data;
-            std::copy(data_ptr, data_ptr + GTElement::SIZE, data.data());
+            std::copy(data_ptr, data_ptr + data.size(), data.data());
             py::gil_scoped_release release;
             return GTElement::FromBytes(data);
         }))
@@ -650,7 +650,7 @@ PYBIND11_MODULE(blspy, m)
             if (_PyLong_AsByteArray(
                     (PyLongObject *)pyint.ptr(),
                     buffer.data(),
-                    GTElement::SIZE,
+                    buffer.size(),
                     0,
                     0) < 0) {
                 throw std::invalid_argument("Failed to cast int to GTElement");
@@ -672,7 +672,7 @@ PYBIND11_MODULE(blspy, m)
                 }
                 auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
                 std::array<uint8_t, GTElement::SIZE> data;
-                std::copy(data_ptr, data_ptr + GTElement::SIZE, data.data());
+                std::copy(data_ptr, data_ptr + data.size(), data.data());
                 py::gil_scoped_release release;
                 return GTElement::FromBytes(data);
             })
@@ -690,7 +690,7 @@ PYBIND11_MODULE(blspy, m)
                 }
                 auto data_ptr = reinterpret_cast<const uint8_t *>(info.ptr);
                 std::array<uint8_t, GTElement::SIZE> data;
-                std::copy(data_ptr, data_ptr + GTElement::SIZE, data.data());
+                std::copy(data_ptr, data_ptr + data.size(), data.data());
                 py::gil_scoped_release release;
                 return GTElement::FromBytesUnchecked(data);
             })

--- a/python-bindings/pythonbindings.cpp
+++ b/python-bindings/pythonbindings.cpp
@@ -637,7 +637,7 @@ PYBIND11_MODULE(blspy, m)
 
             if ((int)info.size != GTElement::SIZE) {
                 throw std::invalid_argument(
-                    "Length of bytes object not equal to G2Element::SIZE");
+                    "Length of bytes object not equal to GTElement::SIZE");
             }
             auto data_ptr = static_cast<uint8_t *>(info.ptr);
             std::array<uint8_t, GTElement::SIZE> data;
@@ -646,7 +646,7 @@ PYBIND11_MODULE(blspy, m)
             return GTElement::FromBytes(data);
         }))
         .def(py::init([](py::int_ pyint) {
-            std::array<uint8_t, G1Element::SIZE> buffer{};
+            std::array<uint8_t, GTElement::SIZE> buffer{};
             if (_PyLong_AsByteArray(
                     (PyLongObject *)pyint.ptr(),
                     buffer.data(),

--- a/rust-bindings/bls-dash-sys/bindings.rs
+++ b/rust-bindings/bls-dash-sys/bindings.rs
@@ -15,6 +15,7 @@ extern "C" {
 
     pub fn G1ElementFromBytes(
         data: *const ::std::os::raw::c_void,
+        len: usize,
         legacy: bool,
         didErr: *mut bool,
     ) -> G1Element;
@@ -43,6 +44,7 @@ extern "C" {
 
     pub fn G2ElementFromBytes(
         data: *const ::std::os::raw::c_void,
+        len: usize,
         legacy: bool,
         didErr: *mut bool,
     ) -> G2Element;
@@ -67,6 +69,7 @@ extern "C" {
 
     pub fn PrivateKeyFromBytes(
         data: *const ::std::os::raw::c_void,
+        len: usize,
         modOrder: bool,
         didErr: *mut bool,
     ) -> PrivateKey;
@@ -355,6 +358,7 @@ extern "C" {
 
     pub fn BIP32ExtendedPublicKeyFromBytes(
         data: *const ::std::os::raw::c_void,
+        len: usize,
         legacy: bool,
         didErr: *mut bool,
     ) -> BIP32ExtendedPublicKey;
@@ -385,6 +389,7 @@ extern "C" {
 
     pub fn BIP32ExtendedPrivateKeyFromBytes(
         data: *const ::std::os::raw::c_void,
+        len: usize,
         didErr: *mut bool,
     ) -> BIP32ExtendedPrivateKey;
 

--- a/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedprivatekey.cpp
+++ b/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedprivatekey.cpp
@@ -6,12 +6,12 @@
 #include "../error.h"
 #include "bls.hpp"
 
-BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromBytes(const void* data, bool* didErr)
+BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromBytes(const void* data, size_t len, bool* didErr)
 {
     bls::ExtendedPrivateKey* el = nullptr;
     try {
         el = new bls::ExtendedPrivateKey(bls::ExtendedPrivateKey::FromBytes(
-            bls::Bytes((uint8_t*)(data), bls::ExtendedPrivateKey::SIZE)));
+            bls::Bytes((uint8_t*)data, len)));
     } catch (const std::exception& ex) {
         gErrMsg = ex.what();
         *didErr = true;
@@ -26,7 +26,7 @@ BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromSeed(const void* data, const 
     bls::ExtendedPrivateKey* el = nullptr;
     try {
         el = new bls::ExtendedPrivateKey(bls::ExtendedPrivateKey::FromSeed(
-            bls::Bytes((uint8_t*)(data), len)));
+            bls::Bytes((uint8_t*)data, len)));
     } catch (const std::exception& ex) {
         gErrMsg = ex.what();
         *didErr = true;

--- a/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedprivatekey.h
+++ b/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedprivatekey.h
@@ -18,6 +18,7 @@ typedef void* BIP32ExtendedPrivateKey;
 // ExtendedPrivateKey
 BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromBytes(
     const void* data,
+    size_t len,
     bool* didErr);
 BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyFromSeed(const void* data, const size_t len, bool* didErr);
 BIP32ExtendedPrivateKey BIP32ExtendedPrivateKeyPrivateChild(

--- a/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedpublickey.cpp
+++ b/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedpublickey.cpp
@@ -8,13 +8,14 @@
 
 BIP32ExtendedPublicKey BIP32ExtendedPublicKeyFromBytes(
     const void* data,
+    size_t len,
     const bool legacy,
     bool* didErr)
 {
     bls::ExtendedPublicKey* el = nullptr;
     try {
         el = new bls::ExtendedPublicKey(bls::ExtendedPublicKey::FromBytes(
-            bls::Bytes((uint8_t*)(data), bls::ExtendedPublicKey::SIZE),
+            bls::Bytes((uint8_t*)data, len),
             legacy));
     } catch (const std::exception& ex) {
         gErrMsg = ex.what();

--- a/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedpublickey.h
+++ b/rust-bindings/bls-dash-sys/c-bindings/bip32/extendedpublickey.h
@@ -16,6 +16,7 @@ typedef void* BIP32ExtendedPublicKey;
 // ExtendedPublicKey
 BIP32ExtendedPublicKey BIP32ExtendedPublicKeyFromBytes(
     const void* data,
+    size_t len,
     const bool legacy,
     bool* didErr);
 BIP32ExtendedPublicKey BIP32ExtendedPublicKeyPublicChild(

--- a/rust-bindings/bls-dash-sys/c-bindings/elements.cpp
+++ b/rust-bindings/bls-dash-sys/c-bindings/elements.cpp
@@ -23,11 +23,11 @@ int G1ElementSize() {
     return bls::G1Element::SIZE;
 }
 
-G1Element G1ElementFromBytes(const void* data, bool legacy, bool* didErr) {
+G1Element G1ElementFromBytes(const void* data, size_t len, bool legacy, bool* didErr) {
     bls::G1Element* el = nullptr;
     try {
         el = new bls::G1Element(
-            bls::G1Element::FromBytes(bls::Bytes((uint8_t*)(data), bls::G1Element::SIZE), legacy)
+            bls::G1Element::FromBytes(bls::Bytes((uint8_t*)data, len), legacy)
         );
     } catch(const std::exception& ex) {
         gErrMsg = ex.what();
@@ -97,11 +97,11 @@ int G2ElementSize() {
     return bls::G2Element::SIZE;
 }
 
-G2Element G2ElementFromBytes(const void* data, const bool legacy, bool* didErr) {
+G2Element G2ElementFromBytes(const void* data, size_t len, const bool legacy, bool* didErr) {
     bls::G2Element* el = nullptr;
     try {
         el = new bls::G2Element(
-            bls::G2Element::FromBytes(bls::Bytes((uint8_t*)data, bls::G2Element::SIZE), legacy)
+            bls::G2Element::FromBytes(bls::Bytes((uint8_t*)data, len), legacy)
         );
         *didErr = false;
     } catch(const std::exception& ex) {

--- a/rust-bindings/bls-dash-sys/c-bindings/elements.h
+++ b/rust-bindings/bls-dash-sys/c-bindings/elements.h
@@ -27,7 +27,7 @@ typedef void* PrivateKey;
 
 // G1Element
 int G1ElementSize();
-G1Element G1ElementFromBytes(const void* data, const bool legacy, bool* didErr);
+G1Element G1ElementFromBytes(const void* data, size_t len, const bool legacy, bool* didErr);
 G1Element G1ElementGenerator();
 bool G1ElementIsValid(const G1Element el);
 uint32_t G1ElementGetFingerprint(const G1Element el, const bool legacy);
@@ -41,7 +41,7 @@ void G1ElementFree(const G1Element el);
 
 // G2Element
 int G2ElementSize();
-G2Element G2ElementFromBytes(const void* data, const bool legacy, bool* didErr);
+G2Element G2ElementFromBytes(const void* data, size_t len, const bool legacy, bool* didErr);
 G2Element G2ElementGenerator();
 bool G2ElementIsValid(const G2Element el);
 bool G2ElementIsEqual(const G2Element el1, const G2Element el2);

--- a/rust-bindings/bls-dash-sys/c-bindings/privatekey.cpp
+++ b/rust-bindings/bls-dash-sys/c-bindings/privatekey.cpp
@@ -20,12 +20,12 @@
 #include "utils.hpp"
 
 // private key bindings implementation
-PrivateKey PrivateKeyFromBytes(const void* data, const bool modOrder, bool* didErr) {
+PrivateKey PrivateKeyFromBytes(const void* data, size_t len, const bool modOrder, bool* didErr) {
     bls::PrivateKey* skPtr = nullptr;
     try {
         skPtr = new bls::PrivateKey(
             bls::PrivateKey::FromBytes(
-                bls::Bytes((uint8_t*)data, bls::PrivateKey::PRIVATE_KEY_SIZE),
+                bls::Bytes((uint8_t*)data, len),
                 modOrder
             )
         );

--- a/rust-bindings/bls-dash-sys/c-bindings/privatekey.h
+++ b/rust-bindings/bls-dash-sys/c-bindings/privatekey.h
@@ -23,7 +23,7 @@ extern "C" {
 
 typedef void* PrivateKey;
 
-PrivateKey PrivateKeyFromBytes(const void* data, const bool modOrder, bool* didErr);
+PrivateKey PrivateKeyFromBytes(const void* data, size_t len, const bool modOrder, bool* didErr);
 PrivateKey PrivateKeyFromSeedBIP32(const void* data, const size_t len);
 PrivateKey PrivateKeyAggregate(void** sks, const size_t len);
 G1Element PrivateKeyGetG1Element(const PrivateKey sk, bool* didErr);

--- a/rust-bindings/bls-signatures/src/bip32/private_key.rs
+++ b/rust-bindings/bls-signatures/src/bip32/private_key.rs
@@ -47,7 +47,7 @@ impl ExtendedPrivateKey {
         }
         Ok(ExtendedPrivateKey {
             c_extended_private_key: c_err_to_result(|did_err| unsafe {
-                BIP32ExtendedPrivateKeyFromBytes(bytes.as_ptr() as *const _, did_err)
+                BIP32ExtendedPrivateKeyFromBytes(bytes.as_ptr() as *const _, bytes.len(), did_err)
             })?,
         })
     }

--- a/rust-bindings/bls-signatures/src/bip32/public_key.rs
+++ b/rust-bindings/bls-signatures/src/bip32/public_key.rs
@@ -42,7 +42,7 @@ impl ExtendedPublicKey {
         }
         Ok(ExtendedPublicKey {
             c_extended_public_key: c_err_to_result(|did_err| unsafe {
-                BIP32ExtendedPublicKeyFromBytes(bytes.as_ptr() as *const _, legacy, did_err)
+                BIP32ExtendedPublicKeyFromBytes(bytes.as_ptr() as *const _, bytes.len(), legacy, did_err)
             })?,
         })
     }

--- a/rust-bindings/bls-signatures/src/elements.rs
+++ b/rust-bindings/bls-signatures/src/elements.rs
@@ -75,7 +75,7 @@ impl G1Element {
         }
         Ok(G1Element {
             c_element: c_err_to_result(|did_err| unsafe {
-                G1ElementFromBytes(bytes.as_ptr() as *const _, legacy, did_err)
+                G1ElementFromBytes(bytes.as_ptr() as *const _, bytes.len(), legacy, did_err)
             })?,
         })
     }
@@ -234,7 +234,7 @@ impl G2Element {
         }
         Ok(G2Element {
             c_element: c_err_to_result(|did_err| unsafe {
-                G2ElementFromBytes(bytes.as_ptr() as *const _, legacy, did_err)
+                G2ElementFromBytes(bytes.as_ptr() as *const _, bytes.len(), legacy, did_err)
             })?,
         })
     }

--- a/rust-bindings/bls-signatures/src/private_key.rs
+++ b/rust-bindings/bls-signatures/src/private_key.rs
@@ -137,7 +137,7 @@ impl PrivateKey {
         }
 
         let c_private_key = c_err_to_result(|did_err| unsafe {
-            PrivateKeyFromBytes(bytes.as_ptr() as *const c_void, mod_order, did_err)
+            PrivateKeyFromBytes(bytes.as_ptr() as *const c_void, bytes.len(), mod_order, did_err)
         })?;
 
         Ok(PrivateKey { c_private_key })


### PR DESCRIPTION
## Additional Information

* The enablement of macOS bindings revealed a potential cause for concern ([build](https://github.com/dashpay/bls-signatures/actions/runs/19167240390/job/54790728889?pr=117#step:12:39)). The binds so far take in a buffer and _assume_ it has a sane size.

  https://github.com/dashpay/bls-signatures/blob/dd683653c6eaba7235bc9c600f46bafbb8210291/go-bindings/elements.cpp#L26-L31

  Which makes the in-library check useless as the condition will _always_ be met.

  https://github.com/dashpay/bls-signatures/blob/dd683653c6eaba7235bc9c600f46bafbb8210291/src/elements.cpp#L34-L36

  To resolve this, when specifying a buffer, you must _also_ specify the size, preferably reported by the object controlling the buffer (like `buf.size()`) instead of hardcoding it (like `PrivateKey::PRIVATE_KEY_SIZE`).

* In [bls-signatures#117](https://github.com/dashpay/bls-signatures/pull/117), CodeRabbit identified a typo in the Python bindings ([source](https://github.com/dashpay/bls-signatures/pull/117#discussion_r2502903244)) utilising the wrong `SIZE` variable. This has been resolved.

## Breaking changes

The introduction of a `size` parameter may require updating function calls to affected bindings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated deserialization functions across language bindings (Go, Rust, Python, C) to require explicit buffer length parameters, replacing implicit fixed-size assumptions. This change improves safety and provides more flexible data handling for key and element reconstruction from byte arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->