### PR TITLE
fix: enforce BLS spec KeyValidate and normalize error handling

### DIFF
--- a/include/dashbls/schemes.hpp
+++ b/include/dashbls/schemes.hpp
@@ -186,6 +186,10 @@ public:
     bool AggregateVerify(const vector<G1Element>& pubkeys,
                          const vector<Bytes>& messages,
                          const G2Element& signature) override;
+
+    bool VerifySecure(const std::vector<G1Element>& vecPublicKeys,
+                      const G2Element& signature,
+                      const Bytes& message) override;
 };
 
 class PopSchemeMPL final : public CoreMPL {

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -140,10 +140,10 @@ bool CoreMPL::Verify(const G1Element& pubkey, const Bytes& message, const G2Elem
     std::array<g2_t, 2> g2s;
 
     G1Element::Generator().Negate().ToNative(g1s[0]);
-    if (!pubkey.IsValid()) {
+    if (!pubkey.IsValid() || pubkey == G1Element()) {
         return false;
     }
-    if (!signature.IsValid()) {
+    if (!signature.IsValid() || signature == G2Element()) {
         return false;
     }
     pubkey.ToNative(g1s[1]);
@@ -232,6 +232,15 @@ bool CoreMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
                            const G2Element& signature,
                            const Bytes& message,
                            const bool fLegacy) {
+    for (const auto& pk : vecPublicKeys) {
+        if (pk == G1Element()) {
+            return false;
+        }
+    }
+    if (signature == G2Element()) {
+        return false;
+    }
+
     BnArrayGuard computedTs(vecPublicKeys.size());
     std::vector<std::array<uint8_t, G1Element::SIZE>> vecSorted(vecPublicKeys.size());
     for (size_t i = 0; i < vecPublicKeys.size(); i++) {
@@ -307,13 +316,13 @@ bool CoreMPL::AggregateVerify(const vector<G1Element>& pubkeys,
     std::vector<g1_st> vecG1(nPubKeys + 1);
     std::vector<g2_st> vecG2(nPubKeys + 1);
     G1Element::Generator().Negate().ToNative(&vecG1[0]);
-    if (!signature.IsValid()) {
+    if (!signature.IsValid() || signature == G2Element()) {
         return false;
     }
     signature.ToNative(&vecG2[0]);
 
     for (size_t i = 0; i < nPubKeys; ++i) {
-        if (!pubkeys[i].IsValid()) {
+        if (!pubkeys[i].IsValid() || pubkeys[i] == G1Element()) {
             return false;
         }
         pubkeys[i].ToNative(&vecG1[i + 1]);
@@ -558,6 +567,43 @@ bool AugSchemeMPL::AggregateVerify(const vector<G1Element>& pubkeys,
     return CoreMPL::AggregateVerify(pubkeys, augMessages, signature);
 }
 
+bool AugSchemeMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
+                                 const G2Element& signature,
+                                 const Bytes& message) {
+    // AugSchemeMPL overrides AggregateVerify to prepend pubkeys to messages.
+    // CoreMPL::VerifySecure calls AggregateVerify virtually, which would
+    // cause double-augmentation. Bypass by calling CoreMPL::AggregateVerify
+    // directly after computing the combined public key.
+    for (const auto& pk : vecPublicKeys) {
+        if (pk == G1Element()) {
+            return false;
+        }
+    }
+    if (signature == G2Element()) {
+        return false;
+    }
+
+    BnArrayGuard computedTs(vecPublicKeys.size());
+    std::vector<std::array<uint8_t, G1Element::SIZE>> vecSorted(vecPublicKeys.size());
+    for (size_t i = 0; i < vecPublicKeys.size(); i++) {
+        vecSorted[i] = vecPublicKeys[i].SerializeToArray(false);
+    }
+    std::sort(vecSorted.begin(), vecSorted.end(), [](const auto& a, const auto& b) -> bool {
+        return std::memcmp(a.data(), b.data(), G1Element::SIZE) < 0;
+    });
+
+    HashPubKeys(computedTs.data, vecSorted.size(),
+                [&](size_t i) { return vecSorted[i].data(); });
+
+    G1Element publicKey;
+    for (size_t i = 0; i < vecSorted.size(); ++i) {
+        G1Element g1 = G1Element::FromBytes(Bytes(vecSorted[i]), false);
+        publicKey += g1 * computedTs[i];
+    }
+
+    return CoreMPL::AggregateVerify({publicKey}, {message}, {signature});
+}
+
 G2Element PopSchemeMPL::PopProve(const PrivateKey &seckey)
 {
     const G1Element& pk = seckey.GetG1Element();
@@ -594,17 +640,15 @@ bool PopSchemeMPL::PopVerify(const vector<uint8_t> &pubkey, const vector<uint8_t
 
 bool PopSchemeMPL::PopVerify(const Bytes& pubkey, const Bytes& proof)
 {
-    const G2Element hashedPoint = G2Element::FromMessage(pubkey, (const uint8_t*)POP_CIPHERSUITE_ID.c_str(), POP_CIPHERSUITE_ID.length());
-
-    g1_t g1s[2];
-    g2_t g2s[2];
-
-    G1Element::Generator().Negate().ToNative(g1s[0]);
-    G1Element::FromBytes(pubkey).ToNative(g1s[1]);
-    G2Element::FromBytes(proof).ToNative(g2s[0]);
-    hashedPoint.ToNative(g2s[1]);
-
-    return CoreMPL::NativeVerify(g1s, g2s, 2);
+    G1Element pk;
+    G2Element proofElement;
+    try {
+        pk = G1Element::FromBytes(pubkey);
+        proofElement = G2Element::FromBytes(proof);
+    } catch (...) {
+        return false;
+    }
+    return PopSchemeMPL::PopVerify(pk, proofElement);
 }
 
 bool PopSchemeMPL::FastAggregateVerify(const vector<G1Element> &pubkeys,
@@ -661,6 +705,12 @@ bool LegacySchemeMPL::Verify(const G1Element &pubkey, const Bytes& message, cons
     g2_t g2s[2];
 
     G1Element::Generator().Negate().ToNative(g1s[0]);
+    if (!pubkey.IsValid() || pubkey == G1Element()) {
+        return false;
+    }
+    if (!signature.IsValid() || signature == G2Element()) {
+        return false;
+    }
     pubkey.ToNative(g1s[1]);
     signature.ToNative(g2s[0]);
     G2Element::FromMessage(message, nullptr, 0, true).ToNative(g2s[1]);
@@ -691,9 +741,15 @@ bool LegacySchemeMPL::AggregateVerify(const vector<G1Element> &pubkeys,
     std::vector<g1_st> vecG1(nPubKeys + 1);
     std::vector<g2_st> vecG2(nPubKeys + 1);
     G1Element::Generator().Negate().ToNative(&vecG1[0]);
+    if (!signature.IsValid() || signature == G2Element()) {
+        return false;
+    }
     signature.ToNative(&vecG2[0]);
 
     for (size_t i = 0; i < nPubKeys; ++i) {
+        if (!pubkeys[i].IsValid() || pubkeys[i] == G1Element()) {
+            return false;
+        }
         pubkeys[i].ToNative(&vecG1[i + 1]);
         G2Element::FromMessage(messages[i], nullptr, 0, true).ToNative(&vecG2[i + 1]);
     }

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -233,11 +233,11 @@ bool CoreMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
                            const Bytes& message,
                            const bool fLegacy) {
     for (const auto& pk : vecPublicKeys) {
-        if (pk == G1Element()) {
+        if (!pk.IsValid() || pk == G1Element()) {
             return false;
         }
     }
-    if (signature == G2Element()) {
+    if (!signature.IsValid() || signature == G2Element()) {
         return false;
     }
 
@@ -575,11 +575,11 @@ bool AugSchemeMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
     // cause double-augmentation. Bypass by calling CoreMPL::AggregateVerify
     // directly after computing the combined public key.
     for (const auto& pk : vecPublicKeys) {
-        if (pk == G1Element()) {
+        if (!pk.IsValid() || pk == G1Element()) {
             return false;
         }
     }
-    if (signature == G2Element()) {
+    if (!signature.IsValid() || signature == G2Element()) {
         return false;
     }
 

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -570,10 +570,10 @@ bool AugSchemeMPL::AggregateVerify(const vector<G1Element>& pubkeys,
 bool AugSchemeMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
                                  const G2Element& signature,
                                  const Bytes& message) {
-    // AugSchemeMPL overrides AggregateVerify to prepend pubkeys to messages.
-    // CoreMPL::VerifySecure calls AggregateVerify virtually, which would
-    // cause double-augmentation. Bypass by calling CoreMPL::AggregateVerify
-    // directly after computing the combined public key.
+    // AugSchemeMPL::Sign hashes H(pk_i || msg) per signer.  We cannot
+    // combine into a single pubkey because each signer's hash is different.
+    // Instead, pass T-weighted individual pubkeys with their augmented
+    // messages to CoreMPL::AggregateVerify.
     for (const auto& pk : vecPublicKeys) {
         if (!pk.IsValid() || pk == G1Element()) {
             return false;
@@ -595,13 +595,17 @@ bool AugSchemeMPL::VerifySecure(const std::vector<G1Element>& vecPublicKeys,
     HashPubKeys(computedTs.data, vecSorted.size(),
                 [&](size_t i) { return vecSorted[i].data(); });
 
-    G1Element publicKey;
+    std::vector<G1Element> weightedPks(vecSorted.size());
+    std::vector<std::vector<uint8_t>> augMessages(vecSorted.size());
     for (size_t i = 0; i < vecSorted.size(); ++i) {
         G1Element g1 = G1Element::FromBytes(Bytes(vecSorted[i]), false);
-        publicKey += g1 * computedTs[i];
+        weightedPks[i] = g1 * computedTs[i];
+        augMessages[i].reserve(G1Element::SIZE + message.size());
+        augMessages[i].insert(augMessages[i].end(), vecSorted[i].begin(), vecSorted[i].end());
+        augMessages[i].insert(augMessages[i].end(), message.begin(), message.end());
     }
 
-    return CoreMPL::AggregateVerify({publicKey}, {message}, {signature});
+    return CoreMPL::AggregateVerify(weightedPks, augMessages, signature);
 }
 
 G2Element PopSchemeMPL::PopProve(const PrivateKey &seckey)

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -699,6 +699,9 @@ bool PopSchemeMPL::FastAggregateVerify(const vector<G1Element>& pubkeys,
     if (pubkeys.size() == 0) {
         return false;
     }
+    if (!signature.IsValid() || signature == G2Element()) {
+        return false;
+    }
     for (const auto& pk : pubkeys) {
         if (!pk.IsValid() || pk == G1Element()) {
             return false;

--- a/src/schemes.cpp
+++ b/src/schemes.cpp
@@ -115,14 +115,20 @@ bool CoreMPL::Verify(const vector<uint8_t> &pubkey,
                      const vector<uint8_t> &message,  // unhashed
                      const vector<uint8_t> &signature)
 {
-    return CoreMPL::Verify(G1Element::FromBytes(Bytes(pubkey)),
-                           Bytes(message),
-                           G2Element::FromBytes(Bytes(signature)));
+    return CoreMPL::Verify(Bytes(pubkey), Bytes(message), Bytes(signature));
 }
 
 bool CoreMPL::Verify(const Bytes& pubkey, const Bytes& message, const Bytes& signature)
 {
-    return CoreMPL::Verify(G1Element::FromBytes(pubkey), message, G2Element::FromBytes(signature));
+    G1Element pubkeyElement;
+    G2Element signatureElement;
+    try {
+        pubkeyElement = G1Element::FromBytes(pubkey);
+        signatureElement = G2Element::FromBytes(signature);
+    } catch (...) {
+        return false;
+    }
+    return CoreMPL::Verify(pubkeyElement, message, signatureElement);
 }
 
 bool CoreMPL::Verify(const G1Element &pubkey,
@@ -282,7 +288,12 @@ bool CoreMPL::AggregateVerify(const vector<Bytes>& pubkeys,
                               const Bytes& signature)
 {
     const size_t nPubKeys = pubkeys.size();
-    const G2Element signatureElement = G2Element::FromBytes(signature);
+    G2Element signatureElement;
+    try {
+        signatureElement = G2Element::FromBytes(signature);
+    } catch (...) {
+        return false;
+    }
     const auto arg_check = VerifyAggregateSignatureArguments(nPubKeys, messages.size(), signatureElement);
     if (arg_check != CONTINUE) {
         return arg_check;
@@ -290,8 +301,12 @@ bool CoreMPL::AggregateVerify(const vector<Bytes>& pubkeys,
 
     vector<G1Element> pubkeyElements;
     pubkeyElements.reserve(nPubKeys);
-    for (size_t i = 0; i < nPubKeys; ++i) {
-        pubkeyElements.push_back(G1Element::FromBytes(pubkeys[i]));
+    try {
+        for (size_t i = 0; i < nPubKeys; ++i) {
+            pubkeyElements.push_back(G1Element::FromBytes(pubkeys[i]));
+        }
+    } catch (...) {
+        return false;
     }
     return CoreMPL::AggregateVerify(pubkeyElements, messages, signatureElement);
 }
@@ -374,17 +389,9 @@ bool BasicSchemeMPL::AggregateVerify(const vector<vector<uint8_t>> &pubkeys,
                                      const vector<vector<uint8_t>> &messages,
                                      const vector<uint8_t> &signature)
 {
-    const size_t nPubKeys = pubkeys.size();
-    auto arg_check = VerifyAggregateSignatureArguments(nPubKeys, messages.size(), G2Element::FromByteVector(signature));
-    if (arg_check != CONTINUE) {
-        return arg_check;
-    }
-
-    const std::set<vector<uint8_t>> setMessages(messages.begin(), messages.end());
-    if (setMessages.size() != nPubKeys) {
-        return false;
-    }
-    return CoreMPL::AggregateVerify(pubkeys, messages, signature);
+    const std::vector<Bytes> vecPubKeyBytes(pubkeys.begin(), pubkeys.end());
+    const std::vector<Bytes> vecMessagesBytes(messages.begin(), messages.end());
+    return BasicSchemeMPL::AggregateVerify(vecPubKeyBytes, vecMessagesBytes, Bytes(signature));
 }
 
 bool BasicSchemeMPL::AggregateVerify(const vector<Bytes>& pubkeys,
@@ -392,7 +399,13 @@ bool BasicSchemeMPL::AggregateVerify(const vector<Bytes>& pubkeys,
                                      const Bytes& signature)
 {
     const size_t nPubKeys = pubkeys.size();
-    const auto arg_check = VerifyAggregateSignatureArguments(nPubKeys, messages.size(), G2Element::FromBytes(signature));
+    G2Element signatureElement;
+    try {
+        signatureElement = G2Element::FromBytes(signature);
+    } catch (...) {
+        return false;
+    }
+    const auto arg_check = VerifyAggregateSignatureArguments(nPubKeys, messages.size(), signatureElement);
     if (arg_check != CONTINUE) return arg_check;
 
     std::set<vector<uint8_t>> setMessages;
@@ -402,7 +415,17 @@ bool BasicSchemeMPL::AggregateVerify(const vector<Bytes>& pubkeys,
     if (setMessages.size() != nPubKeys) {
         return false;
     }
-    return CoreMPL::AggregateVerify(pubkeys, messages, signature);
+
+    vector<G1Element> pubkeyElements;
+    pubkeyElements.reserve(nPubKeys);
+    try {
+        for (size_t i = 0; i < nPubKeys; ++i) {
+            pubkeyElements.push_back(G1Element::FromBytes(pubkeys[i]));
+        }
+    } catch (...) {
+        return false;
+    }
+    return CoreMPL::AggregateVerify(pubkeyElements, messages, signatureElement);
 }
 
 bool BasicSchemeMPL::AggregateVerify(const vector<G1Element> &pubkeys,
@@ -520,7 +543,13 @@ bool AugSchemeMPL::AggregateVerify(const vector<Bytes>& pubkeys,
                                    const Bytes& signature)
 {
     size_t nPubKeys = pubkeys.size();
-    auto arg_check = VerifyAggregateSignatureArguments(nPubKeys, messages.size(), G2Element::FromBytes(signature));
+    G2Element signatureElement;
+    try {
+        signatureElement = G2Element::FromBytes(signature);
+    } catch (...) {
+        return false;
+    }
+    auto arg_check = VerifyAggregateSignatureArguments(nPubKeys, messages.size(), signatureElement);
     if (arg_check != CONTINUE) {
         return arg_check;
     }
@@ -618,17 +647,18 @@ G2Element PopSchemeMPL::PopProve(const PrivateKey &seckey)
 
 bool PopSchemeMPL::PopVerify(const G1Element &pubkey, const G2Element &signature_proof)
 {
+    if (!pubkey.IsValid() || pubkey == G1Element()) {
+        return false;
+    }
+    if (!signature_proof.IsValid() || signature_proof == G2Element()) {
+        return false;
+    }
+
     const G2Element hashedPoint = G2Element::FromMessage(pubkey.SerializeToArray(), (const uint8_t*)POP_CIPHERSUITE_ID.c_str(), POP_CIPHERSUITE_ID.length());
 
     g1_t g1s[2];
     g2_t g2s[2];
 
-    if (!pubkey.IsValid()) {
-        return false;
-    }
-    if (!signature_proof.IsValid()) {
-        return false;
-    }
     G1Element::Generator().Negate().ToNative(g1s[0]);
     pubkey.ToNative(g1s[1]);
     signature_proof.ToNative(g2s[0]);
@@ -669,6 +699,11 @@ bool PopSchemeMPL::FastAggregateVerify(const vector<G1Element>& pubkeys,
     if (pubkeys.size() == 0) {
         return false;
     }
+    for (const auto& pk : pubkeys) {
+        if (!pk.IsValid() || pk == G1Element()) {
+            return false;
+        }
+    }
     // No VerifyAggregateSignatureArguments checks required here as we have exactly one pubkey and one message.
     return CoreMPL::Verify(CoreMPL::Aggregate(pubkeys), message, signature);
 }
@@ -691,11 +726,17 @@ bool PopSchemeMPL::FastAggregateVerify(const vector<Bytes>& pubkeys,
     }
 
     vector<G1Element> pkelements;
-    for (size_t i = 0; i < nPubKeys; ++i) {
-        pkelements.push_back(G1Element::FromBytes(pubkeys[i]));
+    G2Element signatureElement;
+    try {
+        for (size_t i = 0; i < nPubKeys; ++i) {
+            pkelements.push_back(G1Element::FromBytes(pubkeys[i]));
+        }
+        signatureElement = G2Element::FromBytes(signature);
+    } catch (...) {
+        return false;
     }
 
-    return PopSchemeMPL::FastAggregateVerify(pkelements, message, G2Element::FromBytes(signature));
+    return PopSchemeMPL::FastAggregateVerify(pkelements, message, signatureElement);
 }
 
 G2Element LegacySchemeMPL::Sign(const PrivateKey& seckey, const Bytes& message)

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1629,6 +1629,50 @@ TEST_CASE("LegacySchemeMPL Verify rejects invalid elements")
         vector<Bytes> msgs = {Bytes(msg)};
         REQUIRE(LegacySchemeMPL().AggregateVerify(pks, msgs, G2Element()) == false);
     }
+
+    SECTION("Verify rejects malformed non-identity pubkey")
+    {
+        string badPointHex =
+            "8d5d0fb73b9c92df4eab4216e48c3e358578b4cc30f82c268bd6fef3bd34b558628daf1afef798d4c3b0fcd8b28c8973";
+        G1Element badPk = G1Element::FromBytesUnchecked(Bytes(Util::HexToBytes(badPointHex)));
+        REQUIRE(badPk.IsValid() == false);
+
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = LegacySchemeMPL().Sign(sk, Bytes(msg));
+        REQUIRE(LegacySchemeMPL().Verify(badPk, Bytes(msg), sig) == false);
+    }
+
+    SECTION("Verify rejects malformed non-identity signature")
+    {
+        // Build an invalid G2 element via native random coordinates
+        g2_t point_native;
+        g2_set_infty(point_native);
+        fp2_rand(point_native->x);
+        fp2_rand(point_native->y);
+        fp2_rand(point_native->z);
+        G2Element badSig = G2Element::FromNative(point_native);
+        REQUIRE(badSig.IsValid() == false);
+
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto msg = getRandomSeed();
+        REQUIRE(LegacySchemeMPL().Verify(pk, Bytes(msg), badSig) == false);
+    }
+
+    SECTION("AggregateVerify rejects malformed non-identity pubkey")
+    {
+        string badPointHex =
+            "8d5d0fb73b9c92df4eab4216e48c3e358578b4cc30f82c268bd6fef3bd34b558628daf1afef798d4c3b0fcd8b28c8973";
+        G1Element badPk = G1Element::FromBytesUnchecked(Bytes(Util::HexToBytes(badPointHex)));
+
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = LegacySchemeMPL().Sign(sk, Bytes(msg));
+        vector<G1Element> pks = {badPk};
+        vector<Bytes> msgs = {Bytes(msg)};
+        REQUIRE(LegacySchemeMPL().AggregateVerify(pks, msgs, sig) == false);
+    }
 }
 
 TEST_CASE("VerifySecure calls CoreMPL::AggregateVerify directly")
@@ -1669,7 +1713,7 @@ TEST_CASE("VerifySecure calls CoreMPL::AggregateVerify directly")
         REQUIRE(AugSchemeMPL().VerifySecure(pks, aggSig, Bytes(msg)));
     }
 
-    SECTION("VerifySecure rejects identity pubkey")
+    SECTION("BasicSchemeMPL VerifySecure rejects identity pubkey")
     {
         auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
         auto msg = getRandomSeed();
@@ -1678,16 +1722,58 @@ TEST_CASE("VerifySecure calls CoreMPL::AggregateVerify directly")
         vector<G1Element> pks = {G1Element()};
         REQUIRE(BasicSchemeMPL().VerifySecure(pks, sig, Bytes(msg)) == false);
     }
+
+    SECTION("BasicSchemeMPL VerifySecure rejects identity signature")
+    {
+        auto sk1 = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto sk2 = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+
+        vector<G1Element> pks = {sk1.GetG1Element(), sk2.GetG1Element()};
+        REQUIRE(BasicSchemeMPL().VerifySecure(pks, G2Element(), Bytes(msg)) == false);
+    }
+
+    SECTION("AugSchemeMPL VerifySecure rejects identity pubkey")
+    {
+        auto sk = AugSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = AugSchemeMPL().Sign(sk, msg);
+
+        vector<G1Element> pks = {G1Element()};
+        REQUIRE(AugSchemeMPL().VerifySecure(pks, sig, Bytes(msg)) == false);
+    }
+
+    SECTION("AugSchemeMPL VerifySecure rejects identity signature")
+    {
+        auto sk1 = AugSchemeMPL().KeyGen(getRandomSeed());
+        auto sk2 = AugSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+
+        vector<G1Element> pks = {sk1.GetG1Element(), sk2.GetG1Element()};
+        REQUIRE(AugSchemeMPL().VerifySecure(pks, G2Element(), Bytes(msg)) == false);
+    }
 }
 
 TEST_CASE("PopSchemeMPL::PopVerify bytes overload consistent error handling")
 {
-    SECTION("Invalid pubkey bytes returns false instead of throwing")
+    SECTION("Malformed pubkey bytes returns false instead of throwing")
     {
         vector<uint8_t> badPk(G1Element::SIZE, 0xff);
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto pop = PopSchemeMPL().PopProve(sk);
+        auto popBytes = pop.Serialize();
+        REQUIRE_NOTHROW(PopSchemeMPL().PopVerify(Bytes(badPk), Bytes(popBytes)));
+        REQUIRE(PopSchemeMPL().PopVerify(Bytes(badPk), Bytes(popBytes)) == false);
+    }
+
+    SECTION("Malformed proof bytes returns false instead of throwing")
+    {
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto pkBytes = pk.Serialize();
         vector<uint8_t> badProof(G2Element::SIZE, 0xff);
-        REQUIRE_NOTHROW(PopSchemeMPL().PopVerify(Bytes(badPk), Bytes(badProof)));
-        REQUIRE(PopSchemeMPL().PopVerify(Bytes(badPk), Bytes(badProof)) == false);
+        REQUIRE_NOTHROW(PopSchemeMPL().PopVerify(Bytes(pkBytes), Bytes(badProof)));
+        REQUIRE(PopSchemeMPL().PopVerify(Bytes(pkBytes), Bytes(badProof)) == false);
     }
 
     SECTION("Valid proof still verifies through bytes overload")

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1651,6 +1651,24 @@ TEST_CASE("VerifySecure calls CoreMPL::AggregateVerify directly")
         REQUIRE(BasicSchemeMPL().VerifySecure(pks, aggSig, Bytes(msg)));
     }
 
+    SECTION("AugSchemeMPL VerifySecure round-trips correctly")
+    {
+        auto sk1 = AugSchemeMPL().KeyGen(getRandomSeed());
+        auto sk2 = AugSchemeMPL().KeyGen(getRandomSeed());
+        auto pk1 = sk1.GetG1Element();
+        auto pk2 = sk2.GetG1Element();
+        auto msg = getRandomSeed();
+
+        auto sig1 = AugSchemeMPL().Sign(sk1, msg);
+        auto sig2 = AugSchemeMPL().Sign(sk2, msg);
+
+        vector<G1Element> pks = {pk1, pk2};
+        vector<G2Element> sigs = {sig1, sig2};
+        auto aggSig = AugSchemeMPL().AggregateSecure(pks, sigs, Bytes(msg));
+
+        REQUIRE(AugSchemeMPL().VerifySecure(pks, aggSig, Bytes(msg)));
+    }
+
     SECTION("VerifySecure rejects identity pubkey")
     {
         auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1878,7 +1878,7 @@ TEST_CASE("PopSchemeMPL::PopVerify rejects identity elements")
     }
 }
 
-TEST_CASE("FastAggregateVerify rejects identity pubkeys in input list")
+TEST_CASE("FastAggregateVerify rejects identity elements")
 {
     SECTION("Identity pubkey in list is rejected")
     {
@@ -1897,6 +1897,32 @@ TEST_CASE("FastAggregateVerify rejects identity pubkeys in input list")
         auto sig = PopSchemeMPL().Sign(sk, msg);
         vector<G1Element> pks = {G1Element()};
         REQUIRE(PopSchemeMPL().FastAggregateVerify(pks, Bytes(msg), sig) == false);
+    }
+
+    SECTION("Identity signature rejected")
+    {
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto msg = getRandomSeed();
+        vector<G1Element> pks = {pk};
+        REQUIRE(PopSchemeMPL().FastAggregateVerify(pks, Bytes(msg), G2Element()) == false);
+    }
+
+    SECTION("Malformed non-identity signature rejected")
+    {
+        g2_t point_native;
+        g2_set_infty(point_native);
+        fp2_rand(point_native->x);
+        fp2_rand(point_native->y);
+        fp2_rand(point_native->z);
+        G2Element badSig = G2Element::FromNative(point_native);
+        REQUIRE(badSig.IsValid() == false);
+
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto msg = getRandomSeed();
+        vector<G1Element> pks = {pk};
+        REQUIRE(PopSchemeMPL().FastAggregateVerify(pks, Bytes(msg), badSig) == false);
     }
 }
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1787,6 +1787,119 @@ TEST_CASE("PopSchemeMPL::PopVerify bytes overload consistent error handling")
     }
 }
 
+TEST_CASE("Bytes overloads return false on malformed input instead of throwing")
+{
+    SECTION("CoreMPL::Verify with malformed pubkey bytes")
+    {
+        vector<uint8_t> badPk(G1Element::SIZE, 0xff);
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = BasicSchemeMPL().Sign(sk, msg);
+        auto sigBytes = sig.Serialize();
+        REQUIRE_NOTHROW(BasicSchemeMPL().Verify(Bytes(badPk), Bytes(msg), Bytes(sigBytes)));
+        REQUIRE(BasicSchemeMPL().Verify(Bytes(badPk), Bytes(msg), Bytes(sigBytes)) == false);
+    }
+
+    SECTION("CoreMPL::Verify with malformed signature bytes")
+    {
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto pkBytes = pk.Serialize();
+        auto msg = getRandomSeed();
+        vector<uint8_t> badSig(G2Element::SIZE, 0xff);
+        REQUIRE_NOTHROW(BasicSchemeMPL().Verify(Bytes(pkBytes), Bytes(msg), Bytes(badSig)));
+        REQUIRE(BasicSchemeMPL().Verify(Bytes(pkBytes), Bytes(msg), Bytes(badSig)) == false);
+    }
+
+    SECTION("CoreMPL::AggregateVerify with malformed pubkey bytes")
+    {
+        vector<uint8_t> badPk(G1Element::SIZE, 0xff);
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = BasicSchemeMPL().Sign(sk, msg);
+        auto sigBytes = sig.Serialize();
+        vector<Bytes> pks = {Bytes(badPk)};
+        vector<Bytes> msgs = {Bytes(msg)};
+        REQUIRE_NOTHROW(BasicSchemeMPL().AggregateVerify(pks, msgs, Bytes(sigBytes)));
+        REQUIRE(BasicSchemeMPL().AggregateVerify(pks, msgs, Bytes(sigBytes)) == false);
+    }
+
+    SECTION("CoreMPL::AggregateVerify with malformed signature bytes")
+    {
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto pkBytes = pk.Serialize();
+        auto msg = getRandomSeed();
+        vector<uint8_t> badSig(G2Element::SIZE, 0xff);
+        vector<Bytes> pks = {Bytes(pkBytes)};
+        vector<Bytes> msgs = {Bytes(msg)};
+        REQUIRE_NOTHROW(BasicSchemeMPL().AggregateVerify(pks, msgs, Bytes(badSig)));
+        REQUIRE(BasicSchemeMPL().AggregateVerify(pks, msgs, Bytes(badSig)) == false);
+    }
+
+    SECTION("FastAggregateVerify with malformed pubkey bytes")
+    {
+        vector<uint8_t> badPk(G1Element::SIZE, 0xff);
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = PopSchemeMPL().Sign(sk, msg);
+        auto sigBytes = sig.Serialize();
+        vector<Bytes> pks = {Bytes(badPk)};
+        REQUIRE_NOTHROW(PopSchemeMPL().FastAggregateVerify(pks, Bytes(msg), Bytes(sigBytes)));
+        REQUIRE(PopSchemeMPL().FastAggregateVerify(pks, Bytes(msg), Bytes(sigBytes)) == false);
+    }
+
+    SECTION("AugSchemeMPL::AggregateVerify with malformed signature bytes")
+    {
+        auto sk = AugSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto pkBytes = pk.Serialize();
+        auto msg = getRandomSeed();
+        vector<uint8_t> badSig(G2Element::SIZE, 0xff);
+        vector<Bytes> pks = {Bytes(pkBytes)};
+        vector<Bytes> msgs = {Bytes(msg)};
+        REQUIRE_NOTHROW(AugSchemeMPL().AggregateVerify(pks, msgs, Bytes(badSig)));
+        REQUIRE(AugSchemeMPL().AggregateVerify(pks, msgs, Bytes(badSig)) == false);
+    }
+}
+
+TEST_CASE("PopSchemeMPL::PopVerify rejects identity elements")
+{
+    SECTION("PopVerify rejects identity pubkey")
+    {
+        REQUIRE(PopSchemeMPL().PopVerify(G1Element(), G2Element()) == false);
+    }
+
+    SECTION("PopVerify rejects identity proof with valid pubkey")
+    {
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        REQUIRE(PopSchemeMPL().PopVerify(pk, G2Element()) == false);
+    }
+}
+
+TEST_CASE("FastAggregateVerify rejects identity pubkeys in input list")
+{
+    SECTION("Identity pubkey in list is rejected")
+    {
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto msg = getRandomSeed();
+        auto sig = PopSchemeMPL().Sign(sk, msg);
+        vector<G1Element> pks = {pk, G1Element()};
+        REQUIRE(PopSchemeMPL().FastAggregateVerify(pks, Bytes(msg), sig) == false);
+    }
+
+    SECTION("All identity pubkeys rejected")
+    {
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = PopSchemeMPL().Sign(sk, msg);
+        vector<G1Element> pks = {G1Element()};
+        REQUIRE(PopSchemeMPL().FastAggregateVerify(pks, Bytes(msg), sig) == false);
+    }
+}
+
 TEST_CASE("CheckValid for Legacy")
 {
     SECTION("Invalid G1 points should throw in CheckValid but not in FromBytes")

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -742,7 +742,28 @@ TEST_CASE("Signature tests")
         REQUIRE(PopSchemeMPL().FastAggregateVerify(pks_as_g1, msg, aggSig) == false);
         REQUIRE(pks_as_bytes.size() == 0);
         REQUIRE(PopSchemeMPL().FastAggregateVerify(pks_as_bytes, msg, aggSig.Serialize()) == false);
+    }
 
+    SECTION("Verification with identity pubkey or signature should fail")
+    {
+        // Single verify: identity pubkey must be rejected
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = BasicSchemeMPL().Sign(sk, msg);
+        REQUIRE(BasicSchemeMPL().Verify(G1Element(), msg, sig) == false);
+
+        // Single verify: identity signature must be rejected
+        auto pk = sk.GetG1Element();
+        REQUIRE(BasicSchemeMPL().Verify(pk, msg, G2Element()) == false);
+
+        // AggregateVerify: identity pubkey in non-empty list must be rejected
+        vector<G1Element> pks = {G1Element()};
+        vector<Bytes> msgs_b = {Bytes(msg)};
+        REQUIRE(BasicSchemeMPL().AggregateVerify(pks, msgs_b, sig) == false);
+
+        // AggregateVerify: identity signature with non-empty pubkeys must be rejected
+        pks = {pk};
+        REQUIRE(BasicSchemeMPL().AggregateVerify(pks, msgs_b, G2Element()) == false);
     }
 }
 
@@ -1568,6 +1589,97 @@ TEST_CASE("CheckValid")
         std::cout <<Util::HexStr(badSer) << std::endl;
 
         REQUIRE_THROWS(G2Element::FromByteVector(badSer));
+    }
+}
+
+TEST_CASE("LegacySchemeMPL Verify rejects invalid elements")
+{
+    SECTION("Verify rejects identity pubkey")
+    {
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = LegacySchemeMPL().Sign(sk, Bytes(msg));
+        REQUIRE(LegacySchemeMPL().Verify(G1Element(), Bytes(msg), sig) == false);
+    }
+
+    SECTION("Verify rejects identity signature")
+    {
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto msg = getRandomSeed();
+        REQUIRE(LegacySchemeMPL().Verify(pk, Bytes(msg), G2Element()) == false);
+    }
+
+    SECTION("AggregateVerify rejects identity pubkey in non-empty list")
+    {
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = LegacySchemeMPL().Sign(sk, Bytes(msg));
+        vector<G1Element> pks = {G1Element()};
+        vector<Bytes> msgs = {Bytes(msg)};
+        REQUIRE(LegacySchemeMPL().AggregateVerify(pks, msgs, sig) == false);
+    }
+
+    SECTION("AggregateVerify rejects identity signature with non-empty pubkeys")
+    {
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto msg = getRandomSeed();
+        vector<G1Element> pks = {pk};
+        vector<Bytes> msgs = {Bytes(msg)};
+        REQUIRE(LegacySchemeMPL().AggregateVerify(pks, msgs, G2Element()) == false);
+    }
+}
+
+TEST_CASE("VerifySecure calls CoreMPL::AggregateVerify directly")
+{
+    SECTION("BasicSchemeMPL VerifySecure round-trips correctly")
+    {
+        auto sk1 = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto sk2 = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto pk1 = sk1.GetG1Element();
+        auto pk2 = sk2.GetG1Element();
+        auto msg = getRandomSeed();
+
+        auto sig1 = BasicSchemeMPL().Sign(sk1, msg);
+        auto sig2 = BasicSchemeMPL().Sign(sk2, msg);
+
+        vector<G1Element> pks = {pk1, pk2};
+        vector<G2Element> sigs = {sig1, sig2};
+        auto aggSig = BasicSchemeMPL().AggregateSecure(pks, sigs, Bytes(msg));
+
+        REQUIRE(BasicSchemeMPL().VerifySecure(pks, aggSig, Bytes(msg)));
+    }
+
+    SECTION("VerifySecure rejects identity pubkey")
+    {
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        auto msg = getRandomSeed();
+        auto sig = BasicSchemeMPL().Sign(sk, msg);
+
+        vector<G1Element> pks = {G1Element()};
+        REQUIRE(BasicSchemeMPL().VerifySecure(pks, sig, Bytes(msg)) == false);
+    }
+}
+
+TEST_CASE("PopSchemeMPL::PopVerify bytes overload consistent error handling")
+{
+    SECTION("Invalid pubkey bytes returns false instead of throwing")
+    {
+        vector<uint8_t> badPk(G1Element::SIZE, 0xff);
+        vector<uint8_t> badProof(G2Element::SIZE, 0xff);
+        REQUIRE_NOTHROW(PopSchemeMPL().PopVerify(Bytes(badPk), Bytes(badProof)));
+        REQUIRE(PopSchemeMPL().PopVerify(Bytes(badPk), Bytes(badProof)) == false);
+    }
+
+    SECTION("Valid proof still verifies through bytes overload")
+    {
+        auto sk = PopSchemeMPL().KeyGen(getRandomSeed());
+        auto pk = sk.GetG1Element();
+        auto pop = PopSchemeMPL().PopProve(sk);
+        auto pkBytes = pk.Serialize();
+        auto popBytes = pop.Serialize();
+        REQUIRE(PopSchemeMPL().PopVerify(Bytes(pkBytes), Bytes(popBytes)));
     }
 }
 


### PR DESCRIPTION
Per [draft-irtf-cfrg-bls-signature-05](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05), KeyValidate (section 2.5) must reject the identity element and CoreVerify (section 2.7) must call KeyValidate before pairing.

- Reject identity public keys in CoreMPL::Verify and CoreMPL::AggregateVerify per KeyValidate (section 2.5), which CoreVerify (section 2.7) and CoreAggregateVerify (section 2.9) require before pairing; the branch also rejects identity signatures there as additional hardening.
- Add IsValid() and identity checks to CoreMPL::VerifySecure and LegacySchemeMPL::Verify/AggregateVerify for defense-in-depth, matching the hardened core verification path.
- Override VerifySecure in AugSchemeMPL to verify T-weighted individual public keys against per-signer augmented messages, since Aug signs H(pk_i || msg) per signer and collapsing to one combined public key would lose that augmentation.
- Make these byte-based verification paths return false on malformed input instead of throwing: CoreMPL::Verify, CoreMPL::AggregateVerify, BasicSchemeMPL::AggregateVerify(Bytes...), AugSchemeMPL::AggregateVerify(Bytes...), PopSchemeMPL::PopVerify(Bytes...), and PopSchemeMPL::FastAggregateVerify(Bytes...).
- Add identity-element rejection to PopSchemeMPL::PopVerify(G1Element, G2Element) in line with PopVerify (section 3.3.3) calling KeyValidate(PK), and move validation before hashing for early exit.
- Add per-public-key validity and identity checks to PopSchemeMPL::FastAggregateVerify; this enforces the non-identity public-key expectation implied by the PopVerify precondition behind section 3.3.4, even though FastAggregateVerify itself delegates to CoreVerify after aggregating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public secure aggregate verification overload for simplified single-call verification.

* **Bug Fixes**
  * Stronger input validation: default/identity keys and invalid signatures are rejected.
  * Byte parsing now fails gracefully (returns false) instead of throwing.
  * Hardened aggregation/verification flows with defensive pre-checks.

* **Tests**
  * Extensive tests for malformed inputs, identity-key rejection, and aggregation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->