### PR TITLE
fix: guard message and tag lengths before they narrow to int

### DIFF
--- a/src/elements.cpp
+++ b/src/elements.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstring>
+#include <limits>
 
 #include "bls.hpp"
 #include "legacy.hpp"
@@ -118,6 +119,12 @@ G1Element G1Element::FromMessage(Bytes const message,
                                  int dst_len)
 {
     G1Element ans;
+    // relic takes the length as an int and md_xmd does not check it, so a
+    // message at or beyond 2 GiB would narrow negative and be widened back
+    // into an enormous read.
+    if (message.size() > (size_t)std::numeric_limits<int>::max()) {
+        throw std::invalid_argument("G1Element::FromMessage: message length exceeds INT_MAX");
+    }
     ep_map_dst(ans.p, message.begin(), (int)message.size(), dst, dst_len);
     BLS::CheckRelicErrors();
     assert(ans.IsValid());
@@ -340,6 +347,9 @@ G2Element G2Element::FromMessage(Bytes const message,
     if (fLegacy) {
         ep2_map_legacy(ans.q, message.begin(), BLS::MESSAGE_HASH_LEN);
     } else {
+        if (message.size() > (size_t)std::numeric_limits<int>::max()) {
+            throw std::invalid_argument("G2Element::FromMessage: message length exceeds INT_MAX");
+        }
         ep2_map_dst(ans.q, message.begin(), (int)message.size(), dst, dst_len);
     }
     BLS::CheckRelicErrors();

--- a/src/privatekey.cpp
+++ b/src/privatekey.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
+
 #include "bls.hpp"
 #include "legacy.hpp"
 
@@ -307,6 +309,12 @@ G2Element PrivateKey::SignG2(
     if (fLegacy) {
         ep2_map_legacy(pt, msg, BLS::MESSAGE_HASH_LEN);
     } else {
+        // Both lengths narrow to int inside relic; a negative dst_len would
+        // also slip md_xmd's 255-byte check.
+        if (len > (size_t)std::numeric_limits<int>::max() ||
+            dst_len > (size_t)std::numeric_limits<int>::max()) {
+            throw std::invalid_argument("PrivateKey::SignG2: length exceeds INT_MAX");
+        }
         ep2_map_dst(pt, msg, len, dst, dst_len);
     }
     

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #define CATCH_CONFIG_RUNNER
+#include <limits>
 #include <thread>
 
 #include "bls.hpp"
@@ -1617,6 +1618,48 @@ TEST_CASE("CheckValid for Legacy")
                 REQUIRE_THROWS(sig.CheckValid());
             }
         }
+    }
+}
+
+TEST_CASE("Message length is rejected before it narrows to int")
+{
+    // relic takes these lengths as an int and md_xmd never checks the message
+    // length, so anything at or beyond 2 GiB would narrow negative and be
+    // widened back into an enormous read. The guards run before the pointer is
+    // touched, so an oversized Bytes can be described without allocating one.
+    const size_t nTooLong = (size_t)std::numeric_limits<int>::max() + 1;
+    const uint8_t dst[] = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
+    uint8_t buf[1] = {0};
+
+    SECTION("G1Element::FromMessage")
+    {
+        REQUIRE_THROWS_AS(
+            G1Element::FromMessage(Bytes(buf, nTooLong), dst, sizeof(dst) - 1),
+            std::invalid_argument);
+    }
+
+    SECTION("G2Element::FromMessage")
+    {
+        REQUIRE_THROWS_AS(
+            G2Element::FromMessage(Bytes(buf, nTooLong), dst, sizeof(dst) - 1),
+            std::invalid_argument);
+    }
+
+    SECTION("PrivateKey::SignG2")
+    {
+        auto sk = BasicSchemeMPL().KeyGen(getRandomSeed());
+        REQUIRE_THROWS_AS(
+            sk.SignG2(buf, nTooLong, dst, sizeof(dst) - 1), std::invalid_argument);
+        // The tag length narrows the same way and would slip md_xmd's 255 check
+        REQUIRE_THROWS_AS(
+            sk.SignG2(buf, 1, dst, nTooLong), std::invalid_argument);
+    }
+
+    SECTION("Lengths within range are still accepted")
+    {
+        auto msg = getRandomSeed();
+        REQUIRE_NOTHROW(G1Element::FromMessage(Bytes(msg), dst, sizeof(dst) - 1));
+        REQUIRE_NOTHROW(G2Element::FromMessage(Bytes(msg), dst, sizeof(dst) - 1));
     }
 }
 


### PR DESCRIPTION
relic takes both lengths as an int, and md_xmd validates only the output and tag lengths, never the message length. A message at or beyond 2 GiB therefore narrowed negative, slipped every check and was widened back to an enormous unsigned length inside SHA256Input, reading far past the end of the buffer.

The Python binds guard their two from_message entry points, but sign, verify and aggregate_verify reach the same narrowing by other routes, as do the Rust and Go binds, whose shims pass a caller-supplied length straight through to Sign and Verify. Guard at the three points where the value actually narrows instead of at each caller:

* G1Element::FromMessage    (src/elements.cpp)
* G2Element::FromMessage    (src/elements.cpp, non-legacy path only)
* PrivateKey::SignG2        (src/privatekey.cpp, message and tag lengths)

Dash Core executes these paths but cannot reach them with an unsafe length: every call site in src/bls/ wraps a uint256, so the length is always 32. This is hardening for the library's public API, not a fix for a reachable defect in Dash Core.

The legacy paths hash a fixed-length digest and are unaffected.

The guards run before the pointer is dereferenced, so the tests can describe an oversized buffer without allocating one.